### PR TITLE
feat: delete mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ This file contains user-defined tags for supported versions and fundamental CLI 
 
 Defined tags are terminated by a **mandatory** # character, which marks start of comment.
 
+You can define either git-mode tags or base-mode tags , each supported when running in the corresponding mode.
+
+Definition of a base-mode tag **must** start with a '?', like so
+```
+?my_value=1# A nice comment
+```
+The '?' character will not be a part of your tag name, it only marks base-mode tags when at the start of a tag name.
+
 ## Beware of spaces:
 
 Space is a valid separator for tag names, so when you want to write a comment (after using #), make sure you put the hashtag directly after your value, like so:
@@ -41,13 +49,14 @@ my_value=1# A nice comment
 ```
 my_value=1 # A bad comment
 ```
-That extra space will hit you hard.
 
 ## try-anvil
 
 Backtraced script running `./anvil` with various flags using the provided ./bin example references.
 
 This command hints you to symlinking `./amboso` to `super_repo/anvil`, and shows differents outputs based on the queries made.
+
+It can now also show how the repo itself complies with amboso specs to run in git mode.
 
 ## bin/
 
@@ -96,7 +105,7 @@ Sticking to a source file name and a target executable name should be pretty eas
 I can't recommend using the -D flag everytime just to tell amboso where to look, but I guess a fallback option to provide a different default directory name than `./bin` could be easily added. TODO coming soon tm
 
 ### git checkout tag && git switch -
-To successfull use git mode, you must assure idempotency of the switch back to the main version. This is accomplished by correctly setting up your `.gitignore`, so that all object files & the executable are always ignored in all supported versions, and by always having the needed directory for any tag ready inside the tagged commit.
+To successfully use git mode, you must assure idempotency of the switch back to the main version. This is accomplished by correctly setting up your `.gitignore`, so that all object files & the executable are always ignored in all supported versions, and by always having the needed directory for any tag ready inside the tagged commit.
 This must be done for the first version you want to support in git mode, and can stay pretty much untouched after.
 Your repo `.gitignore` should include some lines like this:
 

--- a/amboso
+++ b/amboso
@@ -2,7 +2,7 @@
 # Bash script to run a milestone build providing the version number.
 
 prog_name="$0"
-amboso_version="amboso version 1.0.0"
+amboso_version="amboso version 1.1.0"
 
 function echo_amboso_version {
   echo "$amboso_version"
@@ -11,24 +11,59 @@ function echo_amboso_version {
 function set_supported_versions {
   dir=$1
   [[ ! -f $dir/stego.lock ]] && echo -e "[ERROR]    Can't find \"stego.lock\" in ( $dir ).\n" && exit 1
-  k=0
+  git_tags_count=0
+  base_tags_count=0
   j=0
-  while IFS= read -r line; do
+  k=0
+  i=0
+
+  while IFS= read -r line; do {
     #Skip the first four lines, reserved for header, source file and target executable names, and versions header
     [[ $j -lt 5 ]] && j=$((j+1)) && continue
 
+    was_git_tag=0
+    was_base_tag=0
+    for tag in $(echo "$line" | grep -v '^?' | cut -d '#' -f 1 | grep -v '^$'); do {
+      read_git_mode_tags[git_tags_count]="$tag"
+      git_tags_count=$(($git_tags_count+1))
+      was_git_tag=1
+    }
+    done
+    for tag in $(echo "$line" | grep '^?'| cut -d '?' -f2 | cut -d '#' -f 1 | grep -v '^$'); do {
+      read_base_mode_tags[base_tags_count]="$tag"
+      base_tags_count=$(($base_tags_count+1))
+      was_base_tag=1
+    }
+    done
+
     #echo "Text read from file: ( $line )"
     #echo "Text read from file, no comments: ( $( echo "$line" | cut -d '#' -f 1 ) )"
-    read_versions[k]=$(echo "$line" | cut -d '#' -f 1)
-    k=$((k+1))
+    if [[ $base_mode_flag -gt 0 && $was_base_tag -gt 0 ]] ; then {
+      read_versions[k]=${read_base_mode_tags[$k]}
+      k=$((k+1))
+    } elif [[ $git_mode_flag -gt 0 && $was_git_tag -gt 0 ]] ; then {
+      read_versions[k]=${read_git_mode_tags[$k]}
+      k=$((k+1))
+    }
+    fi
+  }
   done < "$dir/stego.lock" 2>/dev/null
   #echo "version array size is " "${#read_versions[@]}" >&2
-  count_versions="${#read_versions[@]}"
+  count_git_versions="${#read_git_mode_tags[@]}"
+  count_base_versions="${#read_base_mode_tags[@]}"
   #echo "$count_versions"
   #echo "version array contents are: ( ${read_versions[@]} )" >&2
-  for i in $(seq 0 $(($count_versions-1))); do
-    supported_versions[i]=${read_versions[i]}
-  done
+  if [[ $base_mode_flag -gt 0 ]] ; then {
+    for i in $(seq 0 $(($count_base_versions-1))); do
+      supported_versions[i]=${read_base_mode_tags[$i]}
+    done
+  } else {
+    for i in $(seq 0 $(($count_git_versions-1))); do
+      supported_versions[i]=${read_git_mode_tags[$i]}
+    done
+  }
+  fi
+
   tot_vers=${#supported_versions[@]}
 }
 
@@ -54,13 +89,35 @@ function set_source_info {
 }
 
 function usage {
+  mode_txt="\033[1;34mgit\e[0m"
+  [[ $base_mode_flag -gt 0 ]] && mode_txt="\033[1;31mbase\e[0m"
   echo -e "Usage: $(basename $prog_name) [OPTION]... VERSION_QUERY\n"
   echo "    Query for a build version"
-  echo -e "\n    $tot_vers Supported local versions:"
-  for i in $(seq 0 $(($tot_vers-1))); do
+  echo -e "\n    $tot_vers Supported tags for current mode ( $mode_txt )."
+  for i in $(seq 0 $(($tot_vers-1))); do { #Print currently supported versions (only ones conforming to mode)
     (( $i % 4 == 0)) && echo -en "\n        "
-    echo -en "${supported_versions[i]}  "
+    echo -en "\033[1;32m${supported_versions[i]}\e[0m  "
+  }
   done
+  #Print remaining read versions not available in current mode
+  if [[ $base_mode_flag -gt 0 ]] ; then {
+    mode_txt="\033[1;34mgit\e[0m"
+    echo -e "\n    $count_git_versions Supported tags, when running in ( $mode_txt ) mode ."
+    for i in $(seq 0 $(($count_git_versions-1))); do {
+      (( $i % 4 == 0)) && echo -en "\n        "
+      echo -en "\033[0;33m${read_git_mode_tags[i]}\e[0m  "
+    }
+    done
+  } else {
+    mode_txt="\033[1;31mbase\e[0m"
+    echo -e "\n    $count_base_versions Supported local versions, when in ( $mode_txt ) mode."
+    for i in $(seq 0 $(($count_base_versions-1))); do {
+      (( $i % 4 == 0)) && echo -en "\n        "
+      echo -en "\033[0;33m${read_base_mode_tags[i]}\e[0m  "
+    }
+    done
+  }
+  fi
   echo -e "\n\n    [OPTIONS]:\n"
   echo -e "        -D TARGET_DIR        directory\n"
   echo -e "                Specifies target directory\n"
@@ -77,11 +134,13 @@ function usage {
   echo -e "        -b        build\n"
   echo -e "                Tries building the binary if it's not available.\n"
   echo -e "        -r        run\n"
-  echo -e "                Specifies you want to run the milestone.\n"
+  echo -e "                Specifies you want to run the tag.\n"
+  echo -e "        -d        delete\n"
+  echo -e "                Deletes queried tag binary and quits.\n"
   echo -e "        -i        init\n"
   echo -e "                Tries building all supported versions.\n"
   echo -e "        -p        purge\n"
-  echo -e "                Removes all milestone binaries and quits.\n"
+  echo -e "                Removes all tags binaries and quits.\n"
   echo -e "        -V        verbose\n"
   echo -e "                More debug output.\n"
   echo -e "        -h        help\n"
@@ -105,6 +164,7 @@ function git_mode_check {
 purge_flag=0
 run_flag=0 #By default we don't run the binary
 build_flag=0
+delete_flag=0
 init_flag=0
 verbose_flag=0
 dir_flag=0
@@ -119,7 +179,7 @@ makefile_version=""
 git_mode_flag=1 #By default we run in git mode
 base_mode_flag=0
 
-while getopts "M:S:E:D:BgVbpHhriv" opt; do
+while getopts "M:S:E:D:BgVbpHhrivd" opt; do
   case $opt in
     S )
       source_name="$OPTARG"
@@ -165,6 +225,9 @@ while getopts "M:S:E:D:BgVbpHhriv" opt; do
     b )
       build_flag=1
       ;;
+    d )
+      delete_flag=1
+      ;;
     i )
       init_flag=1
       ;;
@@ -183,11 +246,12 @@ tot_opts=$OPTIND
 done
 
 #We check again if basemode was requested, as the only flag checked in build stage is git_mode_flag
+#If base_mode_flag is asserted, we always override git_mode_flag
 [[ $base_mode_flag -gt 0 ]] && git_mode_flag=0 && echo -e "\033[1;31m[AMBOSO-MODE]    Running in base mode, expecting full source builds.\e[0m" >&2
 [[ $git_mode_flag -gt 0 ]] && git_mode_check #We are now sure we can quit immediately if not running in a git repo
 
 #We always notify of missing -D argument
-[[ ! $dir_flag -gt 0 ]] && milestones_dir="$(pwd)/bin/" && echo -e "\033[1;33m[DEBUG]    No -D flag, using ./bin for target dir. Run with -v to see more.\e[0m" >&2 #&& usage && exit 1
+[[ ! $dir_flag -gt 0 ]] && milestones_dir="$(pwd)/bin/" && echo -e "\033[1;33m[DEBUG]    No -D flag, using ./bin for target dir. Run with -V to see more.\e[0m" >&2 #&& usage && exit 1
 
 #Check if we are printing help info and exiting early
 if [[ $smallhelp_flag -gt 0 ]]; then {
@@ -208,7 +272,7 @@ fi
 scripts_dir="$milestones_dir" # MUST BE SET before checking for -S and -E
 set_supported_versions "$scripts_dir" # Might as well do it now
 
-#If version for makefile support was not specified, it's read from the file (an empty value would work maybe)
+#If version for makefile support was not specified, it's read from the stego.lock (an empty value would work maybe)
 if [[ -z $makefile_version ]] ; then {
   set_source_info "$milestones_dir"
   makefile_version=${sources_info[2]}
@@ -231,8 +295,6 @@ if [[ -z $source_name ]] ; then {
   [[ $verbose_flag -gt 0 ]] && echo -e "\033[1;33m[DEBUG]    No -S flag, reading stego.lock for target sourcename.\e[0m" >&2 # && usage && exit 1
 }
 fi
-
-#echo "" >&2
 
 #Display needed values if in verbose mose
 [[ $verbose_flag -gt 0 && ! $dir_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using target dir: ( $scripts_dir ).\e[0m" >&2
@@ -262,7 +324,7 @@ if [[ $init_flag -gt 0 ]] ; then {
       count_bins=$(($count_bins +1))
     } else {
       verbose_hint=""
-      [[ $verbose_flag -lt 1 ]] && verbose_hint="Run with -v to see more info."
+      [[ $verbose_flag -lt 1 ]] && verbose_hint="Run with -V to see more info."
       echo -e "\n\033[1;31m[INIT]    Failed build for $init_vers binary. $verbose_hint\e[0m\n"
       #try building again to get more output, since we discarded stderr before
       #
@@ -321,29 +383,72 @@ fi
 #We expect $scripts_dir to end with /
 version=""
 for i in $(seq 0 $(($tot_vers-1))); do
-  [[ $queried_version = ${supported_versions[i]} ]] && version="$queried_version" && script_path=""$scripts_dir"v"$version""
+  [[ $queried_version = ${supported_versions[$i]} ]] && version="$queried_version" && script_path=""$scripts_dir"v"$version""
 done
 
 if [[ -z $version ]]; then {
   #We only freak out if we don't have purge or init flags on
   if [[ $purge_flag -eq 0 && $init_flag -eq 0 ]] ; then {
-    echo -e "\033[1;31m[ERROR]    ( $queried_version ) is not a valid version.\e[0m\n"
+    echo -e "\033[1;31m[ERROR]    ( $queried_version ) is not a supported tag.\e[0m\n"
     echo -e "\033[1;33m           Run with -h for help.\e[0m\n"
     exit 1
   } elif [[ ! -z $queried_version ]] ; then { #We gently tell the user that the version is not supported
     keep_run_txt=""
     [[ $init_flag -gt 0 ]] && keep_run_txt="$mode_txt[INIT]"
     [[ $purge_flag -gt 0 ]] && keep_run_txt="$mode_txt[PURGE]"
-    echo -e "\n\033[1;33m[DEBUG]    ( $queried_version ) is not a supported version, but we keep running to do $keep_run_txt.\e[0m" >&2
+    echo -e "\n\033[1;33m[DEBUG]    ( $queried_version ) is not a supported tag, but we keep running to do $keep_run_txt.\e[0m" >&2
   }
   fi
-  [[ $purge_flag -eq 0 && $init_flag -eq 0 ]] && echo -e "\n\033[1;31m[ERROR]    Invalid version number: ( $version ).\e[0m\n" && usage && exit 1
 }
 fi
+#We now should have a valid $version value, outside of purge or init mode
 
 has_makefile=0
 if [[ $version > $makefile_version || $version = $makefile_version ]] ; then
   has_makefile=1
+fi
+
+#Check if we are deleting and exiting early
+#We skipped first deletion pass if purge mode is requested, since we will enter here later
+if [[ $delete_flag -gt 0 && $purge_flag -eq 0 ]] ; then {
+    clean_res=1
+  if [[ $has_makeclean -gt 0 && $base_mode_flag -gt 0 ]] ; then { #Running in git mode skips make clean
+    tool_txt="make clean"
+    has_bin=0
+    curr_dir=$(realpath .)
+    delete_path="$scripts_dir""v""$version"
+      if [[ ! -d $delete_path ]] ; then {
+        echo -e "\033[1;31m[ERROR]    '$delete_path' is not a valid directory.\n    Check your supported versions for details on ( $version ).\e[0m\n" #>&2
+      } elif [[ -x $scripts_dir/v$version/$exec_entrypoint ]] ; then { #Executable exists
+        has_bin=1 && echo -e "\033[0;33m[DELETE]   ( $version ) has an executable.\e[0m\n" >&2
+        cd "$delete_path"; make clean 2>/dev/null #1>&2
+        clean_res=$?
+        cd "$curr_dir"
+        exit "$clean_res"
+      } else {
+        [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;31m[DELETE]   ( $versions ) does not have an executable at ( $delete_path ).\e[0m\n" # >&2
+           exit 1
+      }
+      fi
+  } else { #Doesn't have Makefile, build method 2. Running in git mode also skips using make clean
+    tool_txt="rm"
+    has_bin=0
+    if [[ -x $scripts_dir"/v$version"/"$exec_entrypoint" ]] ; then {
+      has_bin=1 && echo -e "\033[0;33m[DELETE]    ( $version ) has an executable.\e[0m" #>&2
+    }
+    fi
+    rm $(realpath "$scripts_dir"/"v$version/$exec_entrypoint") #2>/dev/null
+    clean_res=$?
+    if [[ $clean_res -eq 0 ]] ; then {
+      echo -e "\033[0;32m[DELETE]    Success on ( $version ).\e[0m" >&2
+    } else {
+      echo -e "\033[0;31m[DELETE]    Failure on ( $version ).\e[0m" >&2
+    }
+    fi
+    exit "$clean_res"
+  }
+  fi
+}
 fi
 
 #If we can't find the file we may try to build it
@@ -449,7 +554,7 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
   echo -e "\n\033[1;32m[QUERY]    ( $version ) binary is ready at ( $script_path ) .\e[0m" >&2
   [[ $build_flag -gt 0 ]] && echo -e "\033[0;33m[BUILD]    Found binary for ( $version ), won't build.\e[0m" >&2
 } elif [[ ! -z $queried_version ]] ; then {
-  echo -e "\033[1;31m[QUERY]    ( $queried_version ) invalid query, run with -v to see more.\e[0m"
+  echo -e "\033[1;31m[QUERY]    ( $queried_version ) invalid query, run with -V to see more.\e[0m"
 }
 fi
 
@@ -472,42 +577,35 @@ if [[ ! -z $version && $run_flag -eq 1 && -x $script_path/$exec_entrypoint ]] ; 
 }
 fi
 
-#Check if we are purging and exiting early
+#Check if we are purging
 if [[ purge_flag -gt 0 ]]; then
   #echo "" >&2 #This newline can be redirected when doing recursion for init mode
   tot_removed=0
+  tool_txt="rm"
+  has_bin=0
   for i in $(seq 0 $(($tot_vers-1)) ); do
     clean_res=1
     has_makeclean=0
-    purge_vers=${supported_versions[i]}
-    if [[ $purge_vers > "$makefile_version" || $purge_vers = "$makefile_version" ]] ; then
-      [[ $git_mode_flag -eq 0 ]] && has_makeclean=1 #We never use make clean for purge, if in git mode
-    fi
-    if [[ $has_makeclean -gt 0 ]] ; then { #Running in git mode skips make clean
-      tool_txt="make clean"
-      has_bin=0
-      curr_dir=$(realpath .)
-      purge_path="$scripts_dir""v""$purge_vers"
-        if [[ ! -d $purge_path ]] ; then {
-          [[ $verbose_flag -gt 0 ]] && echo -e "\033[1;31m[ERROR]    '$purge_path' is not a valid directory.\n    Check your supported versions for details on ( $purge_vers ).\e[0m\n" >&2
-        } else {
-          [[ -x $scripts_dir/v$purge_vers/$exec_entrypoint ]] && has_bin=1 && [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[PURGE]    $purge_vers has an executable.\e[0m\n" >&2
-          cd "$purge_path"; make clean 2>/dev/null 1>&2
-          clean_res=$?
-          cd "$curr_dir"
-        }
-        fi
-    } else { #Doesn't have Makefile, build method 2. Running in git mode also skips using make clean
-      tool_txt="rm"
-      has_bin=0
-      if [[ -x $scripts_dir"/v$purge_vers"/"$exec_entrypoint" ]] ; then {
-        has_bin=1 && [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[PURGE]    $purge_vers has an executable.\e[0m" >&2
-      }
-      fi
-      rm $(realpath "$scripts_dir"/"v$purge_vers/$exec_entrypoint") 2>/dev/null
-      clean_res=$?
+    purge_vers=${supported_versions[$i]}
+    if [[ -x $scripts_dir/v$purge_vers/$exec_entrypoint ]] ; then {
+      has_bin=1 #&& [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[DELETE]    $version has an executable.\e[0m\n" >&2
+    } else {
+      continue; #We just skip the version
     }
     fi
+    if [[ $purge_vers > "$makefile_version" || $purge_vers = "$makefile_version" ]] ; then
+      [[ $git_mode_flag -eq 0 ]] && has_makeclean=1 && tool_txt="make clean" #We never use make clean for purge, if in git mode
+    fi
+
+    ## Rerun with -d
+    verb=""
+    gitm=""
+    basem=""
+    [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[PURGE]    Trying to delete ( $purge_vers ) ( $(($i+1)) / $tot_vers )" >&2
+    [[ $base_mode_flag -gt 0 ]] && basem="B" #We make sure to pass on eventual base mode to the subcalls
+    [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
+    ( $prog_name -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem" "$purge_vers" ) 2>/dev/null
+    clean_res="$?"
 
     #Check clean result
     if [[ $clean_res -eq 0 && $has_bin -gt 0 ]] ; then {
@@ -515,7 +613,18 @@ if [[ purge_flag -gt 0 ]]; then
       tot_removed=$(($tot_removed +1))
       [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;33m[PURGE]    Removed ( $purge_vers ) using ( $tool_txt ).\e[0m" >&2
     } else {
-      [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;31m[PURGE]    Failed removing ( $purge_vers ) using ( $tool_txt ).\e[0m" >&2
+      verbose_hint=""
+      [[ $verbose_flag -lt 1 ]] && verbose_hint="Run with -V to see more info."
+      echo -e "\n\033[1;31m[PURGE]    Failed delete for ( $purge_vers ) binary. $verbose_hint\e[0m\n"
+      [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;31m[PURGE]    Failed removing ( $purge_vers ) using ( $tool_txt ). $verbose_hint\e[0m" #>&2
+      #try deleting again to get more output, since we discarded stderr before
+      #
+      #we could just pass -v to the first call if we have it on
+      if [[ $verbose_flag -gt 0 ]]; then {
+	echo -e "[PURGE]    Checking errors, running \033[1;33m$(basename "$prog_name") -dV $purge_vers\e[0m." >&2
+	("$prog_name" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -dV"$gitm""$basem" "$purge_vers") #>&2
+      }
+      fi
     }
     fi
 

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -3,6 +3,7 @@ hello_world.c# source file name
 hello_world# executable file name
 0.3.0# make support version
 [Supported versions]
-0.1.0# < 0.3.0, does not have Makefile
-0.9.0# >= 0.3.0, has Makefile
+?0.1.0# < 0.3.0, does not have Makefile
+?0.9.0# >= 0.3.0, has Makefile
 1.0.0# First version with git mode support
+1.1.0# Introduced delete mode

--- a/bin/v1.1.0/.gitignore
+++ b/bin/v1.1.0/.gitignore
@@ -1,0 +1,3 @@
+#amboso compliant version folder, will ignore everything inside BUT the gitignore, to keep the clean dir
+*
+!.gitignore

--- a/hello_world.c
+++ b/hello_world.c
@@ -5,6 +5,6 @@
 int main(void) {
   printf("Hello, World!\n");
   printf("Built using make.\n");
-  printf("Amboso v1.0.0.\n");
+  printf("Amboso v1.1.0.\n");
   return 0;
 }

--- a/try_anvil
+++ b/try_anvil
@@ -123,11 +123,11 @@ HINT " STEP 9/10
 read </dev/tty
 clear
 
-./anvil -rpbV 1.0.0
+./anvil -rpiV 1.0.0
 HINT " STEP 10/10
 
     Run in git mode. 1.0.0 is the first compliant tag for amboso itself.
-    Run, build 1.0.0 and purge, as we didnt clean before.
+    Init, run 1.0.0 and purge, as we didnt clean before.
     When running in git mode, make clean is never called for any tag, so
       the script only removes the target executable from its directory in bin.
     We also removed the symlink to anvil we created before.


### PR DESCRIPTION
chore: updated amboso lock

!fix: correct parsing of stego.lock file

Supported versions for a run are now correctly set depending on the mode

!feat: '?' is now a mandatory marker for base mode tags, so your tag names can't start with ?

chore: updated stego.lock to apply base mode marker

fix: fixed verbose prompts containing v

chore: bumped version number

feat: updated try_anvil to show git mode init

chore: update README