### PR TITLE
feat: proper test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ $ ./try_anvil
 
 TODO: I should probably update `./try_anvil` to show usage of test commands, should some soon.
 
+For now consider:
+
+## Test mode
+
+Running `anvil` with `-t` or `-T` will start test mode.
+
+- If using `-t`, `anvil` will try to run ALL detected executable tests.
+- If using `-T`, `anvil` should only try to test the passed QUERY tag (must be a valid test name).
+
+- Use `-i` to record all the tests stdout and stderr to aptly named files.
+- You can do the same for just 1 file with `-b`.
+
+## Options and usage, hard failure
+
 I'll tell you that even the help option can fail, if you don't point this child to where your targets are and rely on naming your compliant folder "./bin/".
 You have a bin/ directory in the repo to test this behaviour.
 

--- a/amboso
+++ b/amboso
@@ -2,7 +2,7 @@
 # Bash script to run a milestone build providing the version number.
 
 prog_name="$0"
-amboso_currvers="1.2.0"
+amboso_currvers="1.3.0"
 amboso_testflag_version="1.1.2"
 amboso_version="amboso version $amboso_currvers"
 
@@ -92,7 +92,7 @@ function set_source_info {
 
 function set_tests_info {
   dir="$1"
-  [[ ! -f "$dir"/kazoj.lock ]] && echo -e "\033[1;31m[ERROR]    Can't find \"kazoj.lock\" in ( $dir ). Try running with -T to specify the right directory.\e[0m\n" && exit 1
+  [[ ! -f "$dir"/kazoj.lock ]] && echo -e "\033[1;31m[ERROR]    Can't find \"kazoj.lock\" in ( $dir ). Try running with -K to specify the right directory.\e[0m\n" && exit 1
   j=0
   k=0
   while IFS="\n" read -r line; do
@@ -242,6 +242,8 @@ function echo_options {
   echo -e "        -t        test mode\n"
   echo -e "                Tries all defined tests.\n"
   echo -e "    [OPERATIONS]:\n"
+  echo -e "        -T        test mode\n"
+  echo -e "                Tries the queried test.\n"
   echo -e "        -b        build\n"
   echo -e "                Tries building the binary if it's not available.\n"
   echo -e "        -r        run\n"
@@ -261,11 +263,13 @@ function echo_options {
   echo -e "                Specifies sourcefile name for single file mode.\n"
   echo -e "        -M MAKEFILE_SUPPORT       tagname\n"
   echo -e "                Specifies a tag name for lowest version to support make.\n"
-  echo -e "        -T TEST_FOLDER       path\n"
+  echo -e "        -K TEST_FOLDER       path\n"
   echo -e "                Specifies a relative dirname for test folder.\n"
   echo -e "    [INFO]:\n"
   echo -e "        -l/L        list\n"
   echo -e "                Prints supported tags for current mode (all modes if L) and quits.\n"
+  echo -e "        -q        quiet\n"
+  echo -e "                Less debug output, recursive.\n"
   echo -e "        -V        verbose\n"
   echo -e "                More debug output.\n"
   echo -e "        -h/H        help\n"
@@ -320,7 +324,7 @@ function record_test {
   tmp_stderr="$(mktemp)"
   run_test "$tfp" >>"$tmp_stdout" 2>>"$tmp_stderr"
   res=$?
-  #echo "r: $res" >> "$tmp_stdout"
+  echo "r: $res" >> "$tmp_stdout"
   escape_colorcodes "$tmp_stdout" "$tfp.stdout"
   escape_colorcodes "$tmp_stderr" "$tfp.stderr"
   rm -f "$tmp_stdout" || echo "\033[1;31m[ERROR]    Failed removing tmpfile ($tmp_stdout). Why?\n"
@@ -360,6 +364,7 @@ build_flag=0
 delete_flag=0
 init_flag=0
 verbose_flag=0
+quiet_flag=0
 dir_flag=0
 exec_entrypoint= #By default the value is empty
 exec_was_set=0
@@ -372,13 +377,14 @@ makefile_version=""
 git_mode_flag=1 #By default we run in git mode
 base_mode_flag=0
 test_mode_flag=0
+big_test_mode_flag=0
 test_info_was_set=0
 testdir_flag=0
 kazoj_dir=""
 big_list_flag=0
 small_list_flag=0
 
-while getopts "M:S:E:D:T:BgVbpHhrivdlLt" opt; do
+while getopts "M:S:E:D:K:BgVbpHhrivdlLtTq" opt; do
   case $opt in
     S )
       source_name="$OPTARG"
@@ -392,7 +398,7 @@ while getopts "M:S:E:D:T:BgVbpHhrivdlLt" opt; do
       dir_flag=1
       milestones_dir="$OPTARG"
       ;;
-    T )
+    K )
       testdir_flag=1
       kazoj_dir="$OPTARG"
       test_info_was_set=1
@@ -422,8 +428,14 @@ while getopts "M:S:E:D:T:BgVbpHhrivdlLt" opt; do
     t )
       test_mode_flag=1
       ;;
+    T )
+      big_test_mode_flag=1
+      ;;
     V )
       verbose_flag=1
+      ;;
+    q )
+      quiet_flag=1
       ;;
     v )
       echo_amboso_version
@@ -472,14 +484,14 @@ fi
 #We always notify of missing -D argument
 [[ ! $dir_flag -gt 0 ]] && milestones_dir="$(pwd)/bin/" && echo -e "\033[1;33m[DEBUG]    No -D flag, using ( $milestones_dir ) for target dir. Run with -V to see more.\e[0m" >&2 #&& usage && exit 1
 
-#We always notify of missing -T argument, if in test mode
+#We always notify of missing -K argument, if in test mode
 if [[ $test_mode_flag -gt 0 && ! $testdir_flag -gt 0 ]] ; then {
   set_source_info "$milestones_dir"
   kazoj_dir="${sources_info[3]}"
   set_tests_info "$kazoj_dir"
   set_supported_tests "$kazoj_dir"
   #kazoj_dir="$(pwd)/kazoj/"
-  echo -e "\033[1;33m[DEBUG]    No -T flag, using ( $kazoj_dir ) for target dir. Run with -V to see more.\e[0m" >&2 #&& usage && exit 1
+  echo -e "\033[1;33m[DEBUG]    No -K flag, using ( $kazoj_dir ) for target dir. Run with -V to see more.\e[0m" >&2 #&& usage && exit 1
 }
 fi
 
@@ -514,9 +526,9 @@ if [[ -z $kazoj_dir && $test_mode_flag -gt 0 ]] ; then {
        kazoj_dir="./kazoj"
        set_tests_info "$kazoj_dir"
        set_supported_tests "$kazoj_dir"
-       echo -e "\033[1;33m[DEBUG]    No -T flag on a test run (amboso > $amboso_testflag_version), using \"./kazoj\" as tests dir.\e[0m" >&2
+       echo -e "\033[1;33m[DEBUG]    No -K flag on a test run (amboso > $amboso_testflag_version), using \"./kazoj\" as tests dir.\e[0m" >&2
      } else {
-       echo -e "\033[1;33m[DEBUG]    No -T flag on a test run (amboso > $amboso_testflag_version), reading stego.lock.\e[0m" >&2
+       echo -e "\033[1;33m[DEBUG]    No -K flag on a test run (amboso > $amboso_testflag_version), reading stego.lock.\e[0m" >&2
        set_source_info "$milestones_dir"
        kazoj_dir="${sources_info[3]}"
        set_tests_info "$kazoj_dir"
@@ -524,7 +536,7 @@ if [[ -z $kazoj_dir && $test_mode_flag -gt 0 ]] ; then {
      }
      fi
   } else {
-     echo -e "\033[1;31m[ERROR]    No -T flag on a test run, amboso version is < ($amboso_testflag_version).\n    Quitting.\e[0m" #>&2
+     echo -e "\033[1;31m[ERROR]    No -K flag on a test run, amboso version is < ($amboso_testflag_version).\n    Quitting.\e[0m" #>&2
      exit 0;
   }
   fi
@@ -560,35 +572,36 @@ if [[ $big_list_flag -gt 0 ]]; then {
 fi
 
 #If version for makefile support was not specified, it's read from the stego.lock (an empty value would work maybe)
+#We notify in verbose mode or not in quiet mode
 if [[ -z $makefile_version ]] ; then {
   set_source_info "$milestones_dir"
   makefile_version=${sources_info[2]}
-  [[ $verbose_flag -gt 0 ]] && echo -e "\033[1;33m[DEBUG]    No -F flag, reading stego.lock for target makefile support version.\e[0m" >&2 # && usage && exit 1
+  [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[1;33m[DEBUG]    No -F flag, reading stego.lock for target makefile support version.\e[0m" >&2 # && usage && exit 1
 }
 fi
 
-#We notify of missing -E argument if we're in verbose mode
+#We notify of missing -E argument if we're in verbose mode or not in quiet mode
 if [[ -z $exec_entrypoint ]] ; then {
   set_source_info "$milestones_dir"
   exec_entrypoint=${sources_info[1]}
-  [[ $verbose_flag -gt 0 ]] && echo -e "\033[1;33m[DEBUG]    No -E flag, reading stego.lock for target bin.\e[0m" >&2 # && usage && exit 1
+  [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[1;33m[DEBUG]    No -E flag, reading stego.lock for target bin.\e[0m" >&2 # && usage && exit 1
 }
 fi
 
-#We notify of missing -S argument if we're in verbose mode
+#We notify of missing -S argument if we're in verbose mode or not in quiet mode
 if [[ -z $source_name ]] ; then {
   set_source_info "$milestones_dir"
   source_name=${sources_info[0]}
-  [[ $verbose_flag -gt 0 ]] && echo -e "\033[1;33m[DEBUG]    No -S flag, reading stego.lock for target sourcename.\e[0m" >&2 # && usage && exit 1
+  [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[1;33m[DEBUG]    No -S flag, reading stego.lock for target sourcename.\e[0m" >&2 # && usage && exit 1
 }
 fi
 
 #Display needed values if in verbose mose
-[[ $verbose_flag -gt 0 && ! $dir_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using target dir: ( $scripts_dir ).\e[0m" >&2
-[[ $verbose_flag -gt 0 && ! $exec_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using target bin: ( $exec_entrypoint ).\e[0m" >&2
-[[ $verbose_flag -gt 0 && ! $sourcename_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using source file name: ( $source_name ).\e[0m" >&2
-[[ $verbose_flag -gt 0 && ! $vers_make_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tag for make support: ( $makefile_version ) as first tag compiled with make.\e[0m" >&2
-[[ $verbose_flag -gt 0 && $test_mode_flag -gt 0 && ! $test_info_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tests dir: ( $kazoj_dir ).\e[0m" >&2
+[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]]  && [[ ! $dir_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using target dir: ( $scripts_dir ).\e[0m" >&2
+[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && [[ ! $exec_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using target bin: ( $exec_entrypoint ).\e[0m" >&2
+[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && [[ ! $sourcename_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using source file name: ( $source_name ).\e[0m" >&2
+[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && [[ ! $vers_make_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tag for make support: ( $makefile_version ) as first tag compiled with make.\e[0m" >&2
+[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && [[ $test_mode_flag -gt 0 && ! $test_info_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tests dir: ( $kazoj_dir ).\e[0m" >&2
 
 #Check if we are doing init and we're not in test mode
 #Which means we want to build all tags
@@ -603,11 +616,13 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
     verb=""
     gitm=""
     basem=""
+    quietm=""
     [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[INIT]    Trying to build ( $init_vers ) ( $(($i+1)) / $tot_vers )" >&2
     [[ $base_mode_flag -gt 0 ]] && basem="B" #We make sure to pass on eventual base mode to the subcalls
     [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
+    [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet flag mode to the subcalls
     #First pass sets the verbose flag but redirects stderr to /dev/null
-    $prog_name -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -b"$verb""$gitm""$basem" "$init_vers" 2>/dev/null
+    $prog_name -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -b"$verb""$gitm""$basem""$quietm" "$init_vers" 2>/dev/null
     if [[ $? -eq 0 ]] ; then {
       [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[INIT]    $init_vers binary ready.\e[0m" >&2
       count_bins=$(($count_bins +1))
@@ -618,7 +633,7 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
       #try building again to get more output, since we discarded stderr before
       #
       #we could just pass -v to the first call if we have it on
-      if [[ $verbose_flag -gt 0 ]]; then {
+      if [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]]; then {
 	echo -e "[INIT]    Checking errors, running \033[1;33m$(basename "$prog_name") -bV $init_vers\e[0m." >&2
 	("$prog_name" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -bV"$gitm""$basem" "$init_vers") >&2
       }
@@ -641,26 +656,43 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
 }
 fi
 
-if [[ $init_flag -gt 0 && $test_mode_flag -gt 0 && $verbose_flag -gt 0 ]] ; then {
+if [[ $init_flag -gt 0 && $test_mode_flag -gt 0 ]] && [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] ; then {
   echo -e "\033[0;35m[TEST]    [-i]\e[0m    Will record all tests." >&2
 }
 fi
-if [[ $purge_flag -gt 0 && $test_mode_flag -gt 0 && $verbose_flag -gt 0 ]] ; then {
+if [[ $purge_flag -gt 0 && $test_mode_flag -gt 0 ]] && [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] ; then {
   :
   #echo -e "\033[0;35m[TEST]    [-p]\e[0m    Will clean all tests." >&2
 }
 fi
-if [[ $build_flag -gt 0 && $test_mode_flag -gt 0 && $verbose_flag -gt 0 ]] ; then {
+if [[ $build_flag -gt 0 && $test_mode_flag -gt 0 ]] && [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] ; then {
   echo -e "\033[0;35m[TEST]    [-b]\e[0m    Will record test query." >&2
 }
 fi
-if [[ $delete_flag -gt 0 && $test_mode_flag -gt 0 && $verbose_flag -gt 0 ]] ; then {
+if [[ $delete_flag -gt 0 && $test_mode_flag -gt 0 ]] && [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] ; then {
   :
   #echo -e "\033[0;35m[TEST]    [-d]\e[0m    Will clean test query." >&2
 }
 fi
 
-#Version argument is mandatory outside of purge or init mode
+quietm=""
+verbm=""
+[[ $quiet_flag -gt 0 ]] && quietm="q"
+[[ $verbose_flag -gt 0 ]] && verbm="V"
+
+if [[ $test_mode_flag -gt 0 && $big_test_mode_flag -eq 0 ]] ; then {
+  for i in $(seq 0 $(($tot_tests-1))); do {
+    echo -e "\033[1;34m[TEST]    Run:  \"$prog_name -Tt$quietm$verbm -K $kazoj_dir -D $milestones_dir ${supported_tests[$i]}\"\e[0m"
+    "$prog_name" -Tt"$quietm""$verbm" -K "$kazoj_dir" -D "$milestones_dir" "${supported_tests[$i]}"
+  }
+  done
+  #echo -e "\033[0;35m[TEST]    [-d]\e[0m    Will clean test query." >&2
+}
+fi
+
+#Version argument is mandatory outside of:
+  # purge or init mode (when not in test mode
+  # init mode or FULL test mode (when in test mode)
 #check arg num
 # nothing else is allowed
 #shift all the options
@@ -740,7 +772,7 @@ if [[ $test_mode_flag -gt 0 ]]; then {
       [[ $init_flag -gt 0 ]] && keep_run_txt="[INIT]" && echo -e "\033[1;33m[TEST]    ( $query ) is not a supported tag, but we continue to $keep_run_txt.\e[0m" >&2
       [[ $build_flag -gt 0 ]] && keep_run_txt="[BUILD]" && echo -e "\033[1;33m[TEST]    ( $query ) is not a supported tag, but we continue to $keep_run_txt.\e[0m" >&2
     } else {
-      [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;33m[TEST] expected:\n  $test_type\n\n  name: $test_name\n  path: $test_path\e[0m"# >&2
+      [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[0;33m[TEST] expected:\n  $test_type\n\n  name: $test_name\n  path: $test_path\e[0m"# >&2
       echo -e "\033[0;32m[TEST]    target: ( $test_path ).\e[0m\n"
     }
     fi
@@ -767,10 +799,15 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     for i in $(seq 0 $(($tot_tests-1))); do {
       TEST="${supported_tests[$i]}"
       verb=""
-      gitm=""
+      quietm=""
+      [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet flag mode to the subcalls
       [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[TEST]    Recording ALL: ( $(($i+1)) / $tot_tests ) ( $TEST )" >&2
-      ( "$prog_name" -T "$kazoj_dir" -D "$scripts_dir" -b"$verb"t "$TEST" 2>/dev/null ; exit "$?")
-      clean_res="$?"
+      start_t=`date +%s.%N`
+      ( "$prog_name" -K "$kazoj_dir" -D "$scripts_dir" -b"$quietm""$verb"T "$TEST" 2>/dev/null ; exit "$?")
+      record_res="$?"
+      end_t=`date +%s.%N`
+      runtime=$( echo "$end_t - $start_t" | bc -l )
+      echo -e "\n[TEST]    took $runtime s ( $TEST )" >&2
     }
     done
     #init_all_tests "$relative_testpath"
@@ -798,6 +835,8 @@ if [[ $test_mode_flag -gt 0 ]]; then {
   run_tmp_escerr="$(mktemp)"
   echo -e "\033[1;33m[TEST]    Running ( $relative_testpath ).\e[0m"
   run_test "$relative_testpath" >>"$run_tmp_out" 2>>"$run_tmp_err"
+  ran_res=$?
+  echo "r: $ran_res" >> "$run_tmp_out"
   escape_colorcodes_tee "$run_tmp_out" "$run_tmp_escout"
   escape_colorcodes_tee "$run_tmp_err" "$run_tmp_escerr"
   if [[ $build_flag -eq 0 ]] ; then {
@@ -1124,10 +1163,12 @@ if [[ purge_flag -gt 0 ]]; then
     verb=""
     gitm=""
     basem=""
+    quietm=""
     [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[PURGE]    Trying to delete ( $purge_vers ) ( $(($i+1)) / $tot_vers )" >&2
     [[ $base_mode_flag -gt 0 ]] && basem="B" #We make sure to pass on eventual base mode to the subcalls
     [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
-    ( $prog_name -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem" "$purge_vers" ) 2>/dev/null
+    [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet flag mode to the subcalls
+    ( $prog_name -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem""$quietm" "$purge_vers" ) 2>/dev/null
     clean_res="$?"
 
     #Check clean result

--- a/amboso
+++ b/amboso
@@ -372,6 +372,7 @@ makefile_version=""
 git_mode_flag=1 #By default we run in git mode
 base_mode_flag=0
 test_mode_flag=0
+test_info_was_set=0
 testdir_flag=0
 kazoj_dir=""
 big_list_flag=0
@@ -394,6 +395,7 @@ while getopts "M:S:E:D:T:BgVbpHhrivdlLt" opt; do
     T )
       testdir_flag=1
       kazoj_dir="$OPTARG"
+      test_info_was_set=1
       ;;
     M )
       vers_make_flag=1
@@ -470,6 +472,17 @@ fi
 #We always notify of missing -D argument
 [[ ! $dir_flag -gt 0 ]] && milestones_dir="$(pwd)/bin/" && echo -e "\033[1;33m[DEBUG]    No -D flag, using ( $milestones_dir ) for target dir. Run with -V to see more.\e[0m" >&2 #&& usage && exit 1
 
+#We always notify of missing -T argument, if in test mode
+if [[ $test_mode_flag -gt 0 && ! $testdir_flag -gt 0 ]] ; then {
+  set_source_info "$milestones_dir"
+  kazoj_dir="${sources_info[3]}"
+  set_tests_info "$kazoj_dir"
+  set_supported_tests "$kazoj_dir"
+  #kazoj_dir="$(pwd)/kazoj/"
+  echo -e "\033[1;33m[DEBUG]    No -T flag, using ( $kazoj_dir ) for target dir. Run with -V to see more.\e[0m" >&2 #&& usage && exit 1
+}
+fi
+
 #Check if we are printing help info and exiting early
 if [[ $smallhelp_flag -gt 0 ]]; then {
       "$prog_name" -H -D "$milestones_dir" | less
@@ -481,6 +494,7 @@ if [[ $bighelp_flag -gt 0 ]]; then {
       echo_amboso_version
       set_source_info "$milestones_dir"
       set_supported_versions "$milestones_dir"
+      set_supported_versions "$milestones_dir"
       usage
       exit 0
 }
@@ -488,30 +502,37 @@ fi
 
 scripts_dir="$milestones_dir" # MUST BE SET before checking for -S and -E
 set_supported_versions "$scripts_dir" # Might as well do it now
+set_source_info "$milestones_dir"
+kazoj_dir="${sources_info[3]}"
+set_tests_info "$kazoj_dir"
+set_supported_tests "$kazoj_dir"
 
 #If we're in test mode and test dir was not passed, we check if "./kazoj" is a directory and use that. If it isn't, we may get the name from stego.lock. If that is not a directory, we quit immediately.
 if [[ -z $kazoj_dir && $test_mode_flag -gt 0 ]] ; then {
   if [[ "$amboso_currvers" > "$amboso_testflag_version" || "$amboso_currvers" = "$amboso_testflag_version" ]] ; then {
      if [[ -d "./kazoj" ]]; then {
-       kazoj_dir=$(realpath "./kazoj")
+       kazoj_dir="./kazoj"
        set_tests_info "$kazoj_dir"
        set_supported_tests "$kazoj_dir"
        echo -e "\033[1;33m[DEBUG]    No -T flag on a test run (amboso > $amboso_testflag_version), using \"./kazoj\" as tests dir.\e[0m" >&2
      } else {
        echo -e "\033[1;33m[DEBUG]    No -T flag on a test run (amboso > $amboso_testflag_version), reading stego.lock.\e[0m" >&2
        set_source_info "$milestones_dir"
-       kazoj_dir=${sources_info[3]}
+       kazoj_dir="${sources_info[3]}"
        set_tests_info "$kazoj_dir"
        set_supported_tests "$kazoj_dir"
-       #echo_tests_info "$tests_dir"
      }
      fi
   } else {
      echo -e "\033[1;31m[ERROR]    No -T flag on a test run, amboso version is < ($amboso_testflag_version).\n    Quitting.\e[0m" #>&2
+     exit 0;
   }
   fi
 }
 fi
+
+#echo_tests_info "$tests_dir"
+
 
 #Check if we are printing tag list for current mode and exiting early
 if [[ $small_list_flag -gt 0 ]]; then {
@@ -567,7 +588,7 @@ fi
 [[ $verbose_flag -gt 0 && ! $exec_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using target bin: ( $exec_entrypoint ).\e[0m" >&2
 [[ $verbose_flag -gt 0 && ! $sourcename_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using source file name: ( $source_name ).\e[0m" >&2
 [[ $verbose_flag -gt 0 && ! $vers_make_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tag for make support: ( $makefile_version ) as first tag compiled with make.\e[0m" >&2
-[[ $test_mode_flag -gt 0 && ! $testdir_flag -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tests dir: ( $kazoj_dir ).\e[0m" >&2
+[[ $verbose_flag -gt 0 && $test_mode_flag -gt 0 && ! $test_info_was_set -gt 0 ]] && echo -e "\033[0;32m[INFO]    Using tests dir: ( $kazoj_dir ).\e[0m" >&2
 
 #Check if we are doing init and we're not in test mode
 #Which means we want to build all tags
@@ -748,7 +769,7 @@ if [[ $test_mode_flag -gt 0 ]]; then {
       verb=""
       gitm=""
       [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[TEST]    Recording ALL: ( $(($i+1)) / $tot_tests ) ( $TEST )" >&2
-      ( "$prog_name" -D "$scripts_dir" -b"$verb"t "$TEST" 2>/dev/null ; exit "$?")
+      ( "$prog_name" -T "$kazoj_dir" -D "$scripts_dir" -b"$verb"t "$TEST" 2>/dev/null ; exit "$?")
       clean_res="$?"
     }
     done

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -10,3 +10,4 @@ kazoj# tests folder name
 1.1.0# Introduced delete mode
 1.1.2# ( Hotfix ) Introduced list versions flag
 1.2.0# Introduced test mode
+1.3.0#

--- a/bin/v1.3.0/.gitignore
+++ b/bin/v1.3.0/.gitignore
@@ -1,0 +1,3 @@
+#amboso compliant version folder, will ignore everything inside BUT the gitignore, to keep the clean dir
+*
+!.gitignore

--- a/hello_world.c
+++ b/hello_world.c
@@ -1,10 +1,9 @@
 #include <stdio.h>
 #include <unistd.h>
-#include <dirent.h>
 
 int main(void) {
   printf("Hello, World!\n");
-  printf("Built using make.\n");
-  printf("Amboso v1.2.0, now with test mode!\n");
+  printf("Built using make and anvil around it.\n");
+  printf("Amboso v1.3.0, with better test mode!\n");
   return 0;
 }

--- a/kazoj/bone/good_vers
+++ b/kazoj/bone/good_vers
@@ -1,2 +1,2 @@
 #!/bin/bash
-"./amboso" -D "./bin" 1.0.0
+"./amboso" -D "./bin" -q 1.0.0

--- a/kazoj/bone/good_vers.stdout
+++ b/kazoj/bone/good_vers.stdout
@@ -1,2 +1,3 @@
 $
 ^[[1;33m[QUERY]    ( 1.0.0 ) binary not found in ( ./binv1.0.0 ).^[[0m$
+r: 0$

--- a/kazoj/kulpo/bad_vers
+++ b/kazoj/kulpo/bad_vers
@@ -1,2 +1,2 @@
 #!/bin/bash
-"./amboso" -D "./bin" 69
+"./amboso" -D "./bin" -q 69

--- a/kazoj/kulpo/bad_vers.stdout
+++ b/kazoj/kulpo/bad_vers.stdout
@@ -2,3 +2,4 @@
 $
 ^[[1;33m           Run with -h for help.^[[0m$
 $
+r: 0$


### PR DESCRIPTION
# Proper test mode
- Now `-t` flag tries all tests by default.
- Overriding this behaviour should be done using `-T` but I haven't tested all paths, seems to be working.

### Notes
- Added -q option to have less output, still not used anywhere that wasn't verbose only before. May make a nice difference soon.