### PR TITLE
feat: 1.6.1 fetch tags from remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export SHELL=/bin/bash
-VERSION="1.6.0"
+VERSION="1.6.1"
 ECHO_VERSION="./amboso"
 RUN_VERSION := $(shell $(ECHO_VERSION) -v)
 

--- a/amboso
+++ b/amboso
@@ -13,8 +13,8 @@ kernel_release="$(uname -r)"
 kernel_version="$(uname -v)"
 machine_name="$(uname -m)"
 os_name="$(uname -o)"
-amboso_currvers="1.6.0"
-expected_AMBOSO_API_LVL="1.6.0"
+amboso_currvers="1.6.1"
+expected_AMBOSO_API_LVL="1.6.1"
 amboso_testflag_version="1.4.9"
 export AMBOSO_LVL_REC="${AMBOSO_LVL_REC:-0}"
 # check recursion
@@ -451,6 +451,12 @@ kazoj_dir="${sources_info[3]}" #TODO: don't think this should be overwritten her
 use_automake_version="${sources_info[4]}"
 set_tests_info "$kazoj_dir"
 set_supported_tests "$kazoj_dir"
+
+if [[ $verbose_flag -gt 0 ]]; then {
+    echo -e "\033[1;36m[FETCH]    Fetching remote tags\e[0m" >&2
+    check_tags #Lookup tags from remote
+}
+fi
 
 if [[ $verbose_flag -gt 1 ]]; then { #WIP
     echo -e "\033[1;35m[VERB]    SYNCPOINT:  listing tag names\e[0m" >&2

--- a/amboso_fn.sh
+++ b/amboso_fn.sh
@@ -1,4 +1,4 @@
-AMBOSO_API_LVL="1.6.0"
+AMBOSO_API_LVL="1.6.1"
 at () {
     echo -n "{ call: [$(( ${#BASH_LINENO[@]} - 1 ))] "
     for ((i=${#BASH_LINENO[@]}-1;i>=0;i--)); do
@@ -79,6 +79,48 @@ function echo_amboso_version {
 }
 function echo_amboso_version_short {
   echo "$amboso_currvers"
+}
+
+function check_tags {
+	git fetch --tags
+	repo_tags=($(git tag -l))
+
+	if [[ $verbose_flag -gt 1 ]] ; then {
+		for tag in "${read_versions[@]}"; do
+		if [[ " ${repo_tags[@]} " =~ " $tag " ]]; then
+			if [[ $verbose_flag -gt 0 ]] ; then {
+				shown_tag="\033[1;32m$tag\e[0m"
+				echo -e "[AMBOSO]  Read Tag $shown_tag exists in the repo." >&2
+			}
+			fi
+		else {
+			if [[ $verbose_flag -gt 0 ]] ; then {
+				shown_tag="\033[1;31m$tag\e[0m"
+				echo -e "[AMBOSO]  Read Tag $shown_tag is missing in the repo." >&2
+			}
+			fi
+		}
+		fi
+		done
+	}
+	fi
+
+	for tag in "${supported_versions[@]}"; do
+    	if [[ " ${repo_tags[@]} " =~ " $tag " ]]; then {
+		if [[ $verbose_flag -gt 0 ]] ; then {
+    			shown_tag="\033[1;32m$tag\e[0m"
+        		echo -e "[AMBOSO]  Supported Tag $shown_tag exists in the repo." >&2
+		}
+		fi
+	} else {
+		if [[ $verbose_flag -gt 0 ]] ; then {
+    			shown_tag="\033[1;31m$tag\e[0m"
+        		echo -e "[AMBOSO]  Supported Tag $shown_tag is missing in the repo." >&2
+		}
+		fi
+ 	}
+    	fi
+	done
 }
 
 function set_supported_versions {

--- a/example-src/hello_world.c
+++ b/example-src/hello_world.c
@@ -3,6 +3,6 @@
 
 int main(void) {
   printf("Hello, World!\n");
-  printf("amboso v1.6.0\n");
+  printf("amboso v1.6.1\n");
   return 0;
 }


### PR DESCRIPTION
* adds `check_tags`, which can test read versions after retrieving them from `stego.lock`.