### PR TITLE
feat: 1.6.5 add timer, -W, -w, -X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export SHELL=/bin/bash
-VERSION="1.6.4"
-ANVIL_C_HEADER_VERSION="1.6.4"
+VERSION="1.6.5"
+ANVIL_C_HEADER_VERSION="1.6.5"
 ECHO_VERSION="./amboso"
 RUN_VERSION := $(shell $(ECHO_VERSION) -v)
 
@@ -65,6 +65,7 @@ clean:
 	@echo -en "Cleaning build artifacts:    "
 	-rm \.*.o hello_world
 	-rm ./example-src/*.o
+	-rm ./example-src/anvil__hello_world.*
 	@echo -e "\033[1;33mDone.\e[0m"
 
 cleanob:

--- a/amboso
+++ b/amboso
@@ -91,9 +91,10 @@ gen_C_headers_destdir=""
 start_time_flag=0
 start_time_val=""
 start_time_set=0
+show_time_flag=0
 ignore_git_check_flag=0
 
-while getopts "A:M:S:E:D:K:G:W:BgVbpHhrivdlLtTqsczUX" opt; do
+while getopts "A:M:S:E:D:K:G:W:wBgVbpHhrivdlLtTqsczUX" opt; do
   case $opt in
     X )
       ignore_git_check_flag=1
@@ -126,6 +127,9 @@ while getopts "A:M:S:E:D:K:G:W:BgVbpHhrivdlLtTqsczUX" opt; do
     S )
       source_name="$OPTARG"
       sourcename_was_set=1
+      ;;
+    w )
+      show_time_flag=1
       ;;
     W )
       start_time_val="$OPTARG"
@@ -373,6 +377,7 @@ app "$(echo_node loaded_fn silence_check)"
 #We check if we have to silence all subsequent output
 if [[ ( $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ) && $silent_flag -gt 0 ]] ; then {
   echo -e "\033[1;33m[MODE]\e[0m    Running in silent mode, will now suppress all output.\n"
+  echo_timer "$amboso_start_time"  "Silent run, turning off outputs" "2"
   exec 3>&1 &>/dev/null
   echo -e "This output is going to dev null"
   echo -e "This erroutput is going to dev null" >&2
@@ -660,7 +665,9 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ]
     silentm=""
     packm=""
     ignore_gitcheck=""
+    showtimem=""
     [[ $ignore_git_check_flag -gt 0 ]] && ignore_gitcheck="X"
+    [[ $show_time_flag -gt 0 ]] && showtimem="w"
     [[ $pack_flag -gt 0 ]] && packm="z" #Pass pack op mode
     [[ $silent_flag -gt 0 ]] && silentm="s" #Pass silent mode
     [[ $verbose_flag -gt 0 ]] && verb="V" #Pass verbose mode
@@ -669,8 +676,8 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ]
     [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
     [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet mode to the subcalls
     #First pass sets the verbose flag but redirects stderr to /dev/null
-    [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;35m[VERB]    Running \"$(dirname $(basename $prog_name)) -W $amboso_start_time -M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -b$verb$gitm$basem$quietm$silentm$packm$ignore_gitcheck $init_vers\" ( $(($i+1)) / $tot_vers )" >&2
-    "$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -b"$verb""$gitm""$basem""$quietm""$silentm""$packm""$ignore_gitcheck" "$init_vers" 2>/dev/null
+    [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;35m[VERB]    Running \"$(dirname $(basename $prog_name)) -W $amboso_start_time -M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -b$verb$gitm$basem$quietm$silentm$packm$ignore_gitcheck$showtimem $init_vers\" ( $(($i+1)) / $tot_vers )" >&2
+    "$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -b"$verb""$gitm""$basem""$quietm""$silentm""$packm""$ignore_gitcheck""$showtimem" "$init_vers" 2>/dev/null
     if [[ $? -eq 0 ]] ; then {
       [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[INIT]    $init_vers binary ready.\e[0m" >&2
       count_bins=$(($count_bins +1))
@@ -683,7 +690,7 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ]
       #we could just pass -v to the first call if we have it on
       if [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]]; then {
 	echo -e "[INIT]    Checking errors, running \033[1;33m$(basename "$prog_name") -bV$packm$ignore_gitcheck $init_vers\e[0m." >&2
-	("$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -bVV"$gitm""$basem""$packm""$ignore_gitcheck" "$init_vers") >&2
+	("$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -bVV"$gitm""$basem""$packm""$ignore_gitcheck""$showtimem" "$init_vers") >&2
       }
       fi
     }
@@ -737,6 +744,8 @@ if [[ $small_test_mode_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
   quietm=""
   verbm=""
   buildm=""
+  showtimem=""
+  [[ $show_time_flag -gt 0 ]] && showtimem="w"
   [[ $quiet_flag -gt 0 ]] && quietm="q"
   [[ $verbose_flag -gt 0 ]] && verbm="V"
   [[ $build_flag -gt 0 ]] && buildm="b"
@@ -744,9 +753,9 @@ if [[ $small_test_mode_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
 
   start_t_tests=`date +%s.%N`
   for i in $(seq 0 $(($tot_tests-1))); do {
-    [[ $quiet_flag -eq 0 ]] && echo -e "\033[1;35m[TEST-MACRO]    Running:  \"$prog_name -W $amboso_start_time -T$quietm$verbm$buildm -K $kazoj_dir -D $milestones_dir ${supported_tests[$i]}\"\e[0m" >&2
+    [[ $quiet_flag -eq 0 ]] && echo -e "\033[1;35m[TEST-MACRO]    Running:  \"$prog_name -W $amboso_start_time -T$quietm$verbm$buildm$showtimem -K $kazoj_dir -D $milestones_dir ${supported_tests[$i]}\"\e[0m" >&2
     start_t_curr_test=`date +%s.%N`
-    "$prog_name" -W "$amboso_start_time" -T"$quietm$verbm$buildm" -K "$kazoj_dir" -D "$milestones_dir" "${supported_tests[$i]}"
+    "$prog_name" -W "$amboso_start_time" -T"$quietm$verbm$buildm""$showtimem" -K "$kazoj_dir" -D "$milestones_dir" "${supported_tests[$i]}"
     retcod="$?"
     if [[ $retcod -eq 69 ]] ; then {
       echo -e "\033[1;31m[PANIC]    A test call returned 69 while in macro mode. Doing the same.\e[0m\n"
@@ -947,11 +956,13 @@ if [[ $test_mode_flag -gt 0 ]]; then {
       TEST="${supported_tests[$i]}"
       verb=""
       quietm=""
+      showtimem=""
+      [[ $show_time_flag -gt 0 ]] && showtimem="w"
       [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet flag mode to the subcalls
       [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[TEST]    Recording ALL: ( $(($i+1)) / $tot_tests ) ( $TEST )" >&2
-      echo -e "\033[1;35m[TEST]    Running:\e[0m    \033[1;34m\"$prog_name -K $kazoj_dir -D $scripts_dir -bT$quietm$verb $TEST 2>/dev/null \"\e[0m"
+      echo -e "\033[1;35m[TEST]    Running:\e[0m    \033[1;34m\"$prog_name -K $kazoj_dir -D $scripts_dir -bT$quietm$verb$showtimem $TEST 2>/dev/null \"\e[0m"
       start_t=`date +%s.%N`
-      ( "$prog_name" -W "$amboso_start_time" -K "$kazoj_dir" -D "$scripts_dir" -b"$quietm""$verb"T "$TEST" 2>/dev/null ; exit "$?")
+      ( "$prog_name" -W "$amboso_start_time" -K "$kazoj_dir" -D "$scripts_dir" -b"$quietm""$verb""$showtimem"T "$TEST" 2>/dev/null ; exit "$?")
       record_res="$?"
       if [[ $record_res -eq 69 ]]; then {
 	echo -e "\033[1;31m[PANIC]    Unsupported: a test call returned 69. Will do the same.\e[0m\n" &&
@@ -1487,6 +1498,8 @@ if [[ purge_flag -gt 0 ]]; then
     silentm=""
     packm=""
     ignore_gitcheck=""
+    showtimem=""
+    [[ $show_time_flag -gt 0 ]] && showtimem="w"
     [[ $ignore_git_check_flag -gt 0 ]] && ignore_gitcheck="X"
     [[ $pack_flag -gt 0 ]] && packm="z"
     [[ $silent_flag -gt 0 ]] && silentm="s"
@@ -1495,10 +1508,10 @@ if [[ purge_flag -gt 0 ]]; then
     [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
     [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet flag mode to the subcalls
     if [[ $quiet_flag -eq 0 ]] ; then {
-      echo -e "\033[1;35m[PURGE]    Running \"$(basename "$prog_name") -W $amboso_start_time-M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -d$verb$gitm$basem$quietm$silentm$packm$ignore_gitcheck $purge_vers 2>/dev/null\"\e[0m"
+      echo -e "\033[1;35m[PURGE]    Running \"$(basename "$prog_name") -W $amboso_start_time-M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -d$verb$gitm$basem$quietm$silentm$packm$ignore_gitcheck$showtimem $purge_vers 2>/dev/null\"\e[0m"
     }
     fi
-    ( $prog_name -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem""$quietm""$silentm""$packm""$ignore_gitcheck" "$purge_vers" ) 2>/dev/null
+    ( $prog_name -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem""$quietm""$silentm""$packm""$ignore_gitcheck""$showtimem" "$purge_vers" ) 2>/dev/null
     clean_res="$?"
     #To be sure delete OP is gonna be the returning op here, we assume pack just never makes the script return, so it will always go to delete OP safely.
 
@@ -1518,7 +1531,7 @@ if [[ purge_flag -gt 0 ]]; then
       if [[ $verbose_flag -gt 0 ]]; then {
 	echo -e "[PURGE]    Verbose flag was asserted as ($verbose_flag)." >&2
 	echo -e "[PURGE]    Checking errors, running \033[1;33m$(basename "$prog_name") -dVV $purge_vers\e[0m." >&2
-	("$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -dVV"$gitm""$basem""$ignore_gitcheck" "$purge_vers") #>&2
+	("$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -dVV"$gitm""$basem""$ignore_gitcheck""$showtimem" "$purge_vers") #>&2
       }
       fi
     }

--- a/amboso
+++ b/amboso
@@ -1,9 +1,11 @@
 #!/bin/bash
 # Bash script to run a milestone build providing the version number.
 # Will refuse to run as root. We don't need root privileges in here.
+amboso_start_time=`date +%s.%N`
 if [[ "$EUID" -eq 0 ]] ; then {
   echo "[AMBOSO]    Please don't run me as root."
   exit 3
+  echo_timer "$amboso_start_time"  "Root run" "3"
 }
 fi
 # Set recursion env var if not exists
@@ -13,8 +15,8 @@ kernel_release="$(uname -r)"
 kernel_version="$(uname -v)"
 machine_name="$(uname -m)"
 os_name="$(uname -o)"
-amboso_currvers="1.6.4"
-expected_AMBOSO_API_LVL="1.6.4"
+amboso_currvers="1.6.5"
+expected_AMBOSO_API_LVL="1.6.5"
 amboso_testflag_version="1.4.9"
 export AMBOSO_LVL_REC="${AMBOSO_LVL_REC:-0}"
 # check recursion
@@ -22,6 +24,7 @@ if [[ "${AMBOSO_LVL_REC}" -le "2" ]]; then
   [[ $PARENT_COMMAND = "$prog_name" ]] && echo "Unexpected result while checking amboso recursion level." && exit 1
 else
   echo -e "\n[AMBOSO]    Exceeded depth for recursion ( nested ${AMBOSO_LVL_REC} times).\n"
+  echo_timer "$amboso_start_time"  "Excessive recursion" "1"
   exit 69
 fi
 #Increment depth counter
@@ -85,15 +88,23 @@ tell_uname_flag=0
 gen_C_headers_set=0
 gen_C_headers_flag=0
 gen_C_headers_destdir=""
+start_time_flag=0
+start_time_val=""
+start_time_set=0
+ignore_git_check_flag=0
 
-while getopts "A:M:S:E:D:K:G:BgVbpHhrivdlLtTqsczU" opt; do
+while getopts "A:M:S:E:D:K:G:W:BgVbpHhrivdlLtTqsczUX" opt; do
   case $opt in
+    X )
+      ignore_git_check_flag=1
+      ;;
     G )
       gen_C_headers_flag=1
       gen_C_headers_destdir="$OPTARG"
       if [[ ! -d $gen_C_headers_destdir ]] ; then {
 	      echo -e "\033[1;31m[ERROR]    ($gen_C_headers_destdir) was not a valid directory.\e[0m"
 	      echo -e "\033[1;33m[AMBOSO]    Run with -h for help.\e[0m"
+  	      echo_timer "$amboso_start_time"  "Invalid dir for C gen" "1"
 	      exit 1
       } else {
               gen_C_headers_set=1
@@ -115,6 +126,12 @@ while getopts "A:M:S:E:D:K:G:BgVbpHhrivdlLtTqsczU" opt; do
     S )
       source_name="$OPTARG"
       sourcename_was_set=1
+      ;;
+    W )
+      start_time_val="$OPTARG"
+      amboso_start_time="$start_time_val"
+      start_time_set=1
+      start_time_flag=1
       ;;
     E )
       exec_entrypoint="$OPTARG"
@@ -187,10 +204,12 @@ while getopts "A:M:S:E:D:K:G:BgVbpHhrivdlLtTqsczU" opt; do
       ;;
     \? )
       echo "Invalid option: -$OPTARG. Run with -h for help." >&2
+      echo_timer "$amboso_start_time"  "Invalid option: [$OPTARG]" "1"
       exit 1
       ;;
     : )
       echo "Option -$OPTARG requires an argument. Run with -h for help." >&2
+      echo_timer "$amboso_start_time"  "Missing argument: [$OPTARG]" "1"
       exit 1
       ;;
   esac
@@ -219,9 +238,15 @@ if [[ $(basename $(pwd)) == "amboso" ]] ; then {
     [[ $verbose_flag -gt 1 ]] && echo -e "\033[0;35m[PREP]    Running inside amboso dir. Sourcing: \"$amboso_fn_path\".\e[0m" >&2
     source "$amboso_fn_path";
     source_res="$?"
-    [[ $source_res -ne 0 ]] && echo -e "\033[1;31m[PREP]    Failed loading amboso_fn.\n\n    Using file: \"$amboso_fn_path\".\e[0m" >&2 && exit 3
+    if [[ $source_res -ne 0 ]] ; then {
+      echo -e "\033[1;31m[PREP]    Failed loading amboso_fn.\n\n    Using file: \"$amboso_fn_path\".\e[0m" >&2
+      echo_timer "$amboso_start_time"  "Failed load of amboso_fn" "1"
+      exit 3
+    }
+    fi
   } else {
     echo -e "\033[1;31m[ERROR]    Couldn't load amboso_fn, check your symlinks.\e[0m"
+    echo_timer "$amboso_start_time"  "Invalid path [$amboso_fn_path]" "1"
     exit 2
   }
   fi
@@ -242,12 +267,22 @@ if [[ $(basename $(pwd)) == "amboso" ]] ; then {
   fi
   if [[ $try_default -eq 1 && -f /usr/local/bin/amboso_fn.sh ]] ; then { #We only enter here if we failed sourcing
     #We need one more error message to show me are missing functions because of an amboso directory with no file.
-    [[ $found_amboso_dir -gt 0 ]] && echo -e "\033[1;31m[WARN]   Deprecated amboso dir (< 1.4.3) found, as it doesn't provide a function api marker.\e[0m\n" >&2 && exit 3
+    if [[ $found_amboso_dir -gt 0 ]] ; then {
+      echo -e "\033[1;31m[WARN]   Deprecated amboso dir (< 1.4.3) found, as it doesn't provide a function api marker.\e[0m\n" >&2
+      echo_timer "$amboso_start_time"  "Deprecated amboso dir found" "5"
+      exit 3
+    }
+    fi
     amboso_fn_path="/usr/local/bin/amboso_fn.sh"
     [[ $quiet_flag -eq 0 ]] && echo -e "\033[0;35m[WARN]    Fallback to default path for amboso_fn. Sourcing: \"$amboso_fn_path\".\e[0m" >&2
     source "$amboso_fn_path";
     source_res="$?"
-    [[ $source_res -ne 0 ]] && echo -e "\033[1;31m[PREP]    Failed loading amboso_fn. Quitting.\n\n    Using file: \"$amboso_fn_path\".\e[0m" >&2 && exit 3
+    if [[ $source_res -ne 0 ]] ; then {
+      echo -e "\033[1;31m[PREP]    Failed loading amboso_fn. Quitting.\n\n    Using file: \"$amboso_fn_path\".\e[0m" >&2
+      echo_timer "$amboso_start_time"  "Failed loading amboso_fn.sh" "1"
+      exit 3
+    }
+    fi
   }
   fi
 }
@@ -258,6 +293,7 @@ if [[ $source_res -ne 0 ]] ; then {
   app "$(echo_node begin_node failed_sourcing_fn)"
   app "$(echo_node failed_sourcing_fn end_node)"
   end_digraph
+  echo_timer "$amboso_start_time"  "Failed loading amboso_fn.sh" "1"
   exit 2
 }
 fi
@@ -268,6 +304,7 @@ app "$(echo_node begin_node loaded_fn)"
 if [[ $expected_AMBOSO_API_LVL > $AMBOSO_API_LVL ]] ; then {
   echo -e "\033[1;31m[PANIC]    AMBOSO_API_LVL not supported. Needed { \033[1;35m$expected_AMBOSO_API_LVL\033[1;31m } , { \033[1;33m$AMBOSO_API_LVL\033[1;31m } is too low.\n\n    Maybe check your \"amboso_fn.sh\" file.\n\e[0m"
   echo -e "\033[1;31m[PANIC]    Couldn't load functions. Quitting.\e[0m"
+  echo_timer "$amboso_start_time"  "AMBOSO_API_LVL too low." "1"
   exit 2
 } elif [[ $AMBOSO_API_LVL > $expected_AMBOSO_API_LVL ]] ; then {
   [[ $verbose_flag -gt 1 ]] && echo -e "\033[0;31m[WARN]    AMBOSO_API_LVL is greater than expected. Needed { \033[1;35m$expected_AMBOSO_API_LVL\033[0;31m } , { \033[1;34m$AMBOSO_API_LVL\033[0;31m } is higher.\e[0m" >&2
@@ -320,9 +357,11 @@ fi
 
 if [[ $version_flag -eq 1 ]] ; then {
   echo_amboso_version_short
+  echo_timer "$amboso_start_time"  "Version flag, 1" "2"
   exit 0
 } elif [[ $version_flag -gt 1 ]] ; then {
   echo_amboso_version
+  echo_timer "$amboso_start_time"  "Version flag, >1" "2"
   exit 0
 }
 fi
@@ -364,9 +403,14 @@ if [[ $git_mode_flag -gt 0 ]] ; then {
   if [[ $git_mode_check_res -eq 0 ]]; then {
   	[[ $verbose_flag -gt 0 ]] && echo -e "\033[1;33m[GIT]    Status was clean.\e[0m" >&2
   } else {
-  	echo -e "\033[1;31m[GIT]    Status was not clean!\e[0m" >&2
-  	echo -e "\033[1;31m[AMBOSO]    Aborting.\e[0m" >&2
-	exit 1
+  	[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[1;31m[GIT]    Status was not clean!\e[0m" >&2
+        if [[ $ignore_git_check_flag -eq 0 ]]; then {
+  	  [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[1;31m[AMBOSO]    Aborting.\e[0m" >&2
+          echo_timer "$amboso_start_time"  "Dirty git status" "1"
+	  exit 1
+	}
+	fi
+  	[[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[1;35m[AMBOZO]    We ignore this and will waste time.\e[0m" >&2
   }
   fi
 }
@@ -403,6 +447,7 @@ if [[ $test_mode_flag -gt 0 && $test_info_was_set -gt 0 ]] ; then {
     [[ ! -z $cases_dir ]] && echo -e "\033[1;32m[DEBUG]    bone dir: ( $cases_dir )\e[0m" >&2
     [[ ! -z $errors_dir ]] && echo -e "\033[1;32m           kulpo dir: ( $errors_dir )\e[0m" >&2 #&& usage && exit 1
     echo -e "\n\033[1;31m[PANIC]    Running  as \"$prog_name\" in test mode is not supported. Quitting with 69.\e[0m\n" #&& usage && exit 1
+    echo_timer "$amboso_start_time"  "Test calling \"$(basename $prog_name)\" in test mode to run a test with..." "1"
     exit 69
     #We return 69 and will check for this somewhere
   }
@@ -423,6 +468,7 @@ if [[ $test_mode_flag -gt 0 && $test_info_was_set -gt 0 ]] ; then {
     echo -e "\033[1;33m           kulpo dir (NO -K passed to this amboso call): ( $errors_dir )\e[0m" >&2 #&& usage && exit 1
 
     echo -e "\n\033[1;31m[PANIC]    Running  \"$(basename $prog_name)\" using test mode in a program that will be called by test mode is not supported.\e[0m\n" >&2 #&& usage && exit 1
+    echo_timer "$amboso_start_time"  "Test calling \"$(basename $prog_name)\" in test mode to run a test with..." "1"
     exit 1
   }
   fi
@@ -436,6 +482,7 @@ if [[ $smallhelp_flag -gt 0 ]]; then {
     end_digraph
   if [[ $AMBOSO_LVL_REC -gt 1 ]] ; then {
     echo -e "[AMBOSO]    can't ask for help on a recursive call, try running \"$prog_name -h\" from a shell. ( depth $((${AMBOSO_LVL_REC}-1)) )\n\n        args: (\"$@\")" >&2
+    echo_timer "$amboso_start_time"  "Recursive help?" "1"
     exit 1
   }
   fi
@@ -444,6 +491,7 @@ if [[ $smallhelp_flag -gt 0 ]]; then {
 
   echo -e "Try running with with -H for more info.\n"
   #"$prog_name" -H -D "$milestones_dir" | less
+  echo_timer "$amboso_start_time"  "Show help" "2"
   exit 0
 }
 fi
@@ -454,6 +502,7 @@ if [[ $bighelp_flag -gt 0 ]]; then {
     end_digraph
   if [[ $AMBOSO_LVL_REC -gt 1 ]] ; then {
     echo -e "[AMBOSO]    can't ask for help on a recursive call, try running \"$prog_name -H\" from a shell. ( depth $((${AMBOSO_LVL_REC}-1)) )\n\n        args: (\"$@\")" >&2
+    echo_timer "$amboso_start_time"  "Recursive bighelp?" "1"
     exit 1
   }
   fi
@@ -461,6 +510,7 @@ if [[ $bighelp_flag -gt 0 ]]; then {
   set_source_info "$milestones_dir"
   set_supported_versions "$milestones_dir"
   amboso_help
+  echo_timer "$amboso_start_time"  "Show big help" "2"
   exit 0
 }
 fi
@@ -508,7 +558,8 @@ if [[ -z $kazoj_dir && $test_mode_flag -gt 0 ]] ; then {
      fi
   } else {
      echo -e "\033[1;31m[ERROR]    No -K flag on a test run, amboso version is < ($amboso_testflag_version).\n    Quitting.\e[0m" #>&2
-     exit 0;
+     echo_timer "$amboso_start_time"  "No -K on test run" "3"
+     exit 0
   }
   fi
 }
@@ -522,6 +573,7 @@ if [[ $small_list_flag -gt 0 ]]; then {
     echo_tests_info "$kazoj_dir"
   }
   fi
+  echo_timer "$amboso_start_time"  "List tags" "2"
   exit 0
 }
 fi
@@ -535,6 +587,7 @@ if [[ $big_list_flag -gt 0 ]]; then {
     echo_tests_info "$kazoj_dir"
   }
   fi
+  echo_timer "$amboso_start_time"  "List all tags" "2"
   exit 0
 }
 fi
@@ -606,7 +659,8 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ]
     quietm=""
     silentm=""
     packm=""
-
+    ignore_gitcheck=""
+    [[ $ignore_git_check_flag -gt 0 ]] && ignore_gitcheck="X"
     [[ $pack_flag -gt 0 ]] && packm="z" #Pass pack op mode
     [[ $silent_flag -gt 0 ]] && silentm="s" #Pass silent mode
     [[ $verbose_flag -gt 0 ]] && verb="V" #Pass verbose mode
@@ -615,8 +669,8 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ]
     [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
     [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet mode to the subcalls
     #First pass sets the verbose flag but redirects stderr to /dev/null
-    [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;35m[VERB]    Running \"$(dirname $(basename $prog_name)) -M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -b$verb$gitm$basem$quietm$silentm$packm $init_vers\" ( $(($i+1)) / $tot_vers )" >&2
-    "$prog_name" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -b"$verb""$gitm""$basem""$quietm""$silentm""$packm" "$init_vers" 2>/dev/null
+    [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;35m[VERB]    Running \"$(dirname $(basename $prog_name)) -W $amboso_start_time -M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -b$verb$gitm$basem$quietm$silentm$packm$ignore_gitcheck $init_vers\" ( $(($i+1)) / $tot_vers )" >&2
+    "$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -b"$verb""$gitm""$basem""$quietm""$silentm""$packm""$ignore_gitcheck" "$init_vers" 2>/dev/null
     if [[ $? -eq 0 ]] ; then {
       [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[INIT]    $init_vers binary ready.\e[0m" >&2
       count_bins=$(($count_bins +1))
@@ -628,8 +682,8 @@ if [[ $init_flag -gt 0 && $test_mode_flag -eq 0 && $small_test_mode_flag -eq 0 ]
       #
       #we could just pass -v to the first call if we have it on
       if [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]]; then {
-	echo -e "[INIT]    Checking errors, running \033[1;33m$(basename "$prog_name") -bV$packm $init_vers\e[0m." >&2
-	("$prog_name" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -bVV"$gitm""$basem""$packm" "$init_vers") >&2
+	echo -e "[INIT]    Checking errors, running \033[1;33m$(basename "$prog_name") -bV$packm$ignore_gitcheck $init_vers\e[0m." >&2
+	("$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -bVV"$gitm""$basem""$packm""$ignore_gitcheck" "$init_vers") >&2
       }
       fi
     }
@@ -690,11 +744,16 @@ if [[ $small_test_mode_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
 
   start_t_tests=`date +%s.%N`
   for i in $(seq 0 $(($tot_tests-1))); do {
-    [[ $quiet_flag -eq 0 ]] && echo -e "\033[1;35m[TEST-MACRO]    Running:  \"$prog_name -T$quietm$verbm$buildm -K $kazoj_dir -D $milestones_dir ${supported_tests[$i]}\"\e[0m" >&2
+    [[ $quiet_flag -eq 0 ]] && echo -e "\033[1;35m[TEST-MACRO]    Running:  \"$prog_name -W $amboso_start_time -T$quietm$verbm$buildm -K $kazoj_dir -D $milestones_dir ${supported_tests[$i]}\"\e[0m" >&2
     start_t_curr_test=`date +%s.%N`
-    "$prog_name" -T"$quietm$verbm$buildm" -K "$kazoj_dir" -D "$milestones_dir" "${supported_tests[$i]}"
+    "$prog_name" -W "$amboso_start_time" -T"$quietm$verbm$buildm" -K "$kazoj_dir" -D "$milestones_dir" "${supported_tests[$i]}"
     retcod="$?"
-    [[ $retcod -eq 69 ]] && echo -e "\033[1;31m[PANIC]    A test call returned 69 while in macro mode. Doing the same.\e[0m\n" && exit 69
+    if [[ $retcod -eq 69 ]] ; then {
+      echo -e "\033[1;31m[PANIC]    A test call returned 69 while in macro mode. Doing the same.\e[0m\n"
+      echo_timer "$amboso_start_time"  "Test returned 69" "1"
+      exit 69
+    }
+    fi
     end_t_curr_test=`date +%s.%N`
     runtime_curr_test=$( echo "$end_t_curr_test - $start_t_curr_test" | bc -l )
     display_zero=$(echo $runtime_curr_test | cut -d '.' -f 1)
@@ -717,9 +776,11 @@ if [[ $small_test_mode_flag -gt 0 && $test_mode_flag -eq 0 ]] ; then {
   }
   fi
   #echo -e "\033[0;34m[TEST]    Full testing took $display_zero$runtime_tests seconds ( $tot_tests done).\e[0m\n"
+  echo_timer "$amboso_start_time"  "Test macro" "6"
   exit 0
 } elif [[ $small_test_mode_flag -gt 0 && $test_mode_flag -gt 0 ]] ; then {
   echo -e "\033[1;31m[PANIC]    [-t] used with [-T].\n\n        -t is a shortcut to run as -T on all tests found.\e[0m\n"
+  echo_timer "$amboso_start_time"  "Wrong test flag usage" "1"
   exit 1
   echo "UNREACHABLE"
 }
@@ -750,6 +811,7 @@ tot_left_args=$(( $# ))
 if [[ $tot_left_args -gt 1 ]]; then {
   echo -e "\n\033[1;31m[ERROR]    Unknown argument: "$2" (ignoring other $(($tot_left_args-1)) args).\e[0m\n"
   usage
+  echo_timer "$amboso_start_time"  "Unknown arg [$2]" "1"
   exit 1
 }
 fi
@@ -761,6 +823,7 @@ if [[ $tot_left_args -lt 1 && $purge_flag -eq 0 && $init_flag -eq 0 && $test_mod
   end_digraph
   echo -e "\033[1;31m[ERROR]    Missing query.\e[0m\n"
   echo -e "\033[1;33m           Run with -h for help.\e[0m\n"
+  echo_timer "$amboso_start_time"  "Missing query" "1"
   exit 1
 } elif [[ $tot_left_args -lt 1 && $test_mod_flag -gt 0 ]] ; then {
   app "$(echo_node silence_check missing_test_query)"
@@ -833,13 +896,25 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     if [[ -z $test_path && -z $query ]] ; then {
       [[ $quiet_flag -eq 0 ]] && echo -e "\033[0;35m[VERB]    testpath was empty, query was empty. Should quit.\e[0m" >&2
       keep_run_txt=""
-      [[ $init_flag -gt 0 ]] && keep_run_txt="[INIT]" && echo -e "\033[1;33m[TEST]    ( \"empty\"[$query] ) is not a supported tag. $keep_run_txt.\e[0m" >&2 ; exit 1
+      if [[ $init_flag -gt 0 ]] ; then {
+	keep_run_txt="[INIT]"
+       	echo -e "\033[1;33m[TEST]    ( \"empty\"[$query] ) is not a supported tag. $keep_run_txt.\e[0m" >&2
+  	echo_timer "$amboso_start_time"  "Empty test query" "1"
+        exit 1
+      }
+      fi
       echo -e "\033[0;35m[VERB]    UNREACHABLE.\e[0m"
       exit 1
     } elif [[ -z $test_path && ! -z $query ]] ; then {
       [[ $quiet_flag -eq 0 ]] && echo -e "\033[0;35m[VERB]    testpath was empty, query was not empty: ( $query ).\e[0m" >&2
       keep_run_txt=""
-      [[ $init_flag -gt 0 ]] && keep_run_txt="[INIT]" && echo -e "\033[1;33m[TEST]    ( $query ) is not a supported tag, we quit at this point. $keep_run_txt.\e[0m" >&2 && exit 0
+      if [[ $init_flag -gt 0 ]] ; then {
+        keep_run_txt="[INIT]"
+	echo -e "\033[1;33m[TEST]    ( $query ) is not a supported tag, we quit at this point. $keep_run_txt.\e[0m" >&2
+  	echo_timer "$amboso_start_time"  "Unsupported test query [$query]" "3"
+	exit 0
+      }
+      fi
       [[ $build_flag -gt 0 ]] && keep_run_txt="[BUILD]" && echo -e "\033[1;33m[TEST]    ( $query ) is not a supported tag, but we continue to $keep_run_txt.\e[0m" >&2
     } else {
       [[ $verbose_flag -gt 0 || $quiet_flag -eq 0 ]] && echo -e "\033[0;33m[TEST] expected:\n  $test_type\n\n  name: $test_name\n  path: $test_path\e[0m"# >&2
@@ -850,6 +925,7 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     #Panic
     echo -e "\033[1;31m[ERROR]    ( $test_name : at  $test_path ) is not a supported test.\e[0m\n"
     echo -e "\033[1;33m           Run with -h for help.\e[0m\n"
+    echo_timer "$amboso_start_time"  "Unsupported test name [$test_name] at [$test_path]" "1"
     exit 1
   }
   fi
@@ -875,9 +951,14 @@ if [[ $test_mode_flag -gt 0 ]]; then {
       [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[TEST]    Recording ALL: ( $(($i+1)) / $tot_tests ) ( $TEST )" >&2
       echo -e "\033[1;35m[TEST]    Running:\e[0m    \033[1;34m\"$prog_name -K $kazoj_dir -D $scripts_dir -bT$quietm$verb $TEST 2>/dev/null \"\e[0m"
       start_t=`date +%s.%N`
-      ( "$prog_name" -K "$kazoj_dir" -D "$scripts_dir" -b"$quietm""$verb"T "$TEST" 2>/dev/null ; exit "$?")
+      ( "$prog_name" -W "$amboso_start_time" -K "$kazoj_dir" -D "$scripts_dir" -b"$quietm""$verb"T "$TEST" 2>/dev/null ; exit "$?")
       record_res="$?"
-      [[ $record_res -eq 69 ]] && echo -e "\033[1;31m[PANIC]    Unsupported: a test call returned 69. Will do the same.\e[0m\n" && exit 69
+      if [[ $record_res -eq 69 ]]; then {
+	echo -e "\033[1;31m[PANIC]    Unsupported: a test call returned 69. Will do the same.\e[0m\n" &&
+    	echo_timer "$amboso_start_time"  "Record Test call returned 69" "1"
+	exit 69
+      }
+      fi
       end_t=`date +%s.%N`
       runtime=$( echo "$end_t - $start_t" | bc -l )
       echo -e "\n[TEST]    took $runtime s ( $TEST )" >&2
@@ -896,16 +977,20 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     echo -e "\033[1;31m[TEST]    Supported tests:\e[0m"
     echo_tests_info "$kazoj_dir"
     echo -e "\033[1;31m[TEST]    Quitting.\e[0m"
+    echo_timer "$amboso_start_time"  "Invalid target path [$relative_testpath]" "1"
     exit 1
   }
   fi
   if [[ -z $relative_testpath && $init_flag -eq 1 && ! -z $query ]] ; then {
     #Exit 0 as intended behaviour FIXME
-    echo -e "\033[1;31m[ERROR]    Can't proceed even with -i flag, with no testpath. ( p: $relative_testpath ) can't be be ( q: $query ).\e[0m" && exit 0
+    echo -e "\033[1;31m[ERROR]    Can't proceed even with -i flag, with no testpath. ( p: $relative_testpath ) can't be be ( q: $query ).\e[0m"
+    echo_timer "$amboso_start_time"  "Invalid target path (-i) [$relative_testpath]" "1"
+    exit 0
   }
   fi
   if [[ -z $relative_testpath && $init_flag -eq 1 && -z $query ]] ; then {
     echo -e "\033[1;31m[ERROR]    Can't proceed with no query.  ( q: $query, p: $relative_testpath ).\e[0m"
+    echo_timer "$amboso_start_time"  "Empty test query [$query]" "1"
     exit 1
   }
   fi
@@ -930,6 +1015,7 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     rm -f "$run_tmp_escerr" || echo "\033[1;31m[ERROR]    Failed removing tmpfile ($run_tmp_escerr). Why?\n"
     [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[TEST]    Removed tempfile "$run_tmp_escerr".\e[0m" >&2
     echo -e "\033[1;31m[PANIC]    Quitting with 69.\e[0m"
+    echo_timer "$amboso_start_time"  "Test run ended with 69" "1"
     exit 69
   }
   fi
@@ -1026,9 +1112,11 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     echo -e "\033[1;33m[TEST]    Phony pass (recording).\e[0m"
     [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;33m    (out: $out_res)\e[0m"
     [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;33m    (err: $err_res)\e[0m"
+    echo_timer "$amboso_start_time"  "Phony test pass" "3"
     exit 0 #We return earlier
   } elif [[ $out_res = "pass" && $err_res = "pass" ]]; then {
     echo -e "\033[1;32m[TEST]    Passed.\e[0m"
+    echo_timer "$amboso_start_time"  "Test pass" "2"
     exit 0 #We return earlier
   } elif [[ $out_res = "fail" ]] ; then {
    : #echo "failed" #We echoed before
@@ -1038,6 +1126,7 @@ if [[ $test_mode_flag -gt 0 ]]; then {
     echo -e "\033[1;31m[ERROR]    Unexpected values (o:$out_res/e:$err_res) should be either pass or fail.\e[0m. How?"
   }
   fi
+  echo_timer "$amboso_start_time"  "Test fail" "1"
   exit 1
 }
 fi
@@ -1057,12 +1146,14 @@ if [[ -z $version ]]; then {
     end_digraph
     echo -e "\033[1;31m[ERROR]    ( $query ) is not a supported tag.\e[0m\n"
     echo -e "\033[1;33m           Run with -h for help.\e[0m\n"
+    echo_timer "$amboso_start_time"  "Invalid query [$query]" "1"
     exit 1
   } elif [[ ! -z $query && $test_mode_flag -gt 0 ]] ; then { #If we're in test mode, gently tell the user that the version is not supported
     keep_run_txt=""
     [[ $init_flag -gt 0 ]] && keep_run_txt="$mode_txt[INIT]"
     [[ $purge_flag -gt 0 ]] && keep_run_txt="$mode_txt[PURGE]"
     echo -e "\n\033[1;33m[DEBUG]    ( $query ) is not a supported test. $keep_run_txt.\e[0m" >&2
+    echo_timer "$amboso_start_time"  "Invalid test query [$query]" "1"
     exit 1;
   }
   fi
@@ -1102,6 +1193,7 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
     if [[ ! $purge_flag -gt 0 ]] ; then {
      app "$(echo_node query_success_not_ready end_node)"
      end_digraph
+     echo_timer "$amboso_start_time"  "No build flag" "1"
      exit 1 # quit if we're not purging
     }
     fi
@@ -1110,6 +1202,7 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
       echo -e "\033[1;31m[ERROR]    '$script_path' is not a valid directory.\n    Check your supported versions for details on ( $version ).\e[0m\n" >&2
       app "$(echo_node query_success_not_ready end_node)"
       end_digraph
+      echo_timer "$amboso_start_time"  "Invalid path [$script_path]" "1"
       exit 1
     fi
     #we try to build
@@ -1154,7 +1247,12 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
           fi
           git switch - #We get back to starting repo state
           switch_res="$?"
-          [[ $switch_res -gt 0 ]] && echo -e "\n\033[1;31m[ERROR]    Can't finish checking out ($version).\n    You may have a dirty index and may need to run \033[1;35\"git restore .\"\e[0m.\n Abort.\n" && exit 1
+          if [[ $switch_res -gt 0 ]]; then {
+	    echo -e "\n\033[1;31m[ERROR]    Can't finish checking out ($version).\n    You may have a dirty index and may need to run \033[1;35\"git restore .\"\e[0m.\n Abort.\n"
+            echo_timer "$amboso_start_time"  "Failed checkout" "1"
+	    exit 1
+    	  }
+	  fi
           git submodule update --init --recursive #We set all submodules to commit state
           [[ $quiet_flag -eq 0 ]] && echo -e "\033[0;32m[BUILD]    Switched back to starting commit.\e[0m"
         }
@@ -1168,7 +1266,13 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
       [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;33m[MODE]    target ( $version ) < ( $makefile_version ), single file build with gcc.\e[0m" >&2
       [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;33m[BUILD]    Building ( $version ), using gcc call.\e[0m" >&2
       #echo "" >&2 #new line for error output
-      [[ -z $source_name ]] && echo -e "\n\033[1;31m[WTF-ERROR]    Missing source file name. ( $version ).\e[0m\n" && usage && exit 1
+      if [[ -z $source_name ]]; then {
+	echo -e "\n\033[1;31m[WTF-ERROR]    Missing source file name. ( $version ).\e[0m\n"
+	usage
+        echo_timer "$amboso_start_time"  "Missing source name for [$version]" "1"
+	exit 1
+      }
+      fi
       [[ $pack_flag -gt 0 ]] && echo -e "\n\033[1;33m[PACK]    -z is not supported for ($tool_txt). TAG < ($makefile_version).\n\n    \033[1;35Current: ($version @ $source_name).\e[0m\n"
 
       start_t=`date +%s.%N`
@@ -1190,7 +1294,12 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
           #All files generated during the build should be ignored by the repo, to avoid conflict when checking out
           git switch - 2>/dev/null #We get back to starting repo state
           switch_res="$?"
-          [[ $switch_res -gt 0 ]] && echo -e "\n\033[1;31m[ERROR]    Can't finish checkin out ($version). Abort." && exit 1
+          if [[ $switch_res -gt 0 ]]; then {
+	    echo -e "\n\033[1;31m[ERROR]    Can't finish checking out ($version). Abort."
+            echo_timer "$amboso_start_time"  "Failed checkout for [$version]" "1"
+	    exit 1
+          }
+	  fi
           [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;32m[BUILD]    Switched back to starting commit.\e[0m" >&2
         }
         fi
@@ -1209,6 +1318,7 @@ if [[ ! -f "$script_path/$exec_entrypoint" && ! -z $version ]] ; then {
       app "$(echo_node building build_fail)"
       app "$(echo_node build_fail end_node)"
       end_digraph
+      echo_timer "$amboso_start_time"  "Failed build for [$version]" "1"
       exit 1
     fi
 
@@ -1302,12 +1412,14 @@ if [[ $delete_flag -gt 0 && $purge_flag -eq 0 ]] ; then {
         cd "$delete_path"; make clean 2>/dev/null #1>&2
         clean_res=$?
         cd "$curr_dir"
+        echo_timer "$amboso_start_time"  "Did delete, res was [$clean_res]" "3"
         exit "$clean_res"
       } else {
         [[ $verbose_flag -gt 0 ]] && echo -e "\033[0;31m[DELETE]   ( $versions ) does not have an executable at ( $delete_path ).\e[0m\n" # >&2
         app "$(echo_node deleting no_target_error)"
         app "$(echo_node no_target_error end_node)"
         end_digraph
+        echo_timer "$amboso_start_time"  "Nothing to delete" "1"
         exit 1
       }
       fi
@@ -1332,6 +1444,7 @@ if [[ $delete_flag -gt 0 && $purge_flag -eq 0 ]] ; then {
       end_digraph
     }
     fi
+    echo_timer "$amboso_start_time"  "Did delete, res was [$clean_res]" "3"
     exit "$clean_res"
   }
   fi
@@ -1373,6 +1486,8 @@ if [[ purge_flag -gt 0 ]]; then
     quietm=""
     silentm=""
     packm=""
+    ignore_gitcheck=""
+    [[ $ignore_git_check_flag -gt 0 ]] && ignore_gitcheck="X"
     [[ $pack_flag -gt 0 ]] && packm="z"
     [[ $silent_flag -gt 0 ]] && silentm="s"
     [[ $verbose_flag -gt 0 ]] && verb="V" && echo -e "\n[PURGE]    Trying to delete ( $purge_vers ) ( $(($i+1)) / $tot_vers )" >&2
@@ -1380,10 +1495,10 @@ if [[ purge_flag -gt 0 ]]; then
     [[ $git_mode_flag -gt 0 ]] && gitm="g" #We make sure to pass on eventual git mode to the subcalls
     [[ $quiet_flag -gt 0 ]] && quietm="q" #We make sure to pass on eventual quiet flag mode to the subcalls
     if [[ $quiet_flag -eq 0 ]] ; then {
-      echo -e "\033[1;35m[PURGE]    Running \"$(basename "$prog_name") -M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -d$verb$gitm$basem$quietm$silentm$packm $purge_vers 2>/dev/null\"\e[0m"
+      echo -e "\033[1;35m[PURGE]    Running \"$(basename "$prog_name") -W $amboso_start_time-M $makefile_version -S $source_name -E $exec_entrypoint -D $scripts_dir -d$verb$gitm$basem$quietm$silentm$packm$ignore_gitcheck $purge_vers 2>/dev/null\"\e[0m"
     }
     fi
-    ( $prog_name -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem""$quietm""$silentm""$packm" "$purge_vers" ) 2>/dev/null
+    ( $prog_name -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -E "$exec_entrypoint" -D "$scripts_dir" -d"$verb""$gitm""$basem""$quietm""$silentm""$packm""$ignore_gitcheck" "$purge_vers" ) 2>/dev/null
     clean_res="$?"
     #To be sure delete OP is gonna be the returning op here, we assume pack just never makes the script return, so it will always go to delete OP safely.
 
@@ -1403,7 +1518,7 @@ if [[ purge_flag -gt 0 ]]; then
       if [[ $verbose_flag -gt 0 ]]; then {
 	echo -e "[PURGE]    Verbose flag was asserted as ($verbose_flag)." >&2
 	echo -e "[PURGE]    Checking errors, running \033[1;33m$(basename "$prog_name") -dVV $purge_vers\e[0m." >&2
-	("$prog_name" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -dVV"$gitm""$basem" "$purge_vers") #>&2
+	("$prog_name" -W "$amboso_start_time" -M "$makefile_version" -S "$source_name" -D "$scripts_dir" -E "$exec_entrypoint" -dVV"$gitm""$basem""$ignore_gitcheck" "$purge_vers") #>&2
       }
       fi
     }
@@ -1436,5 +1551,5 @@ if [[ $delete_flag -eq 0 ]]; then {
 fi
 
 end_digraph
-
+echo_timer "$amboso_start_time"  "Run" "6"
 exit 0

--- a/amboso_fn.sh
+++ b/amboso_fn.sh
@@ -1,4 +1,4 @@
-AMBOSO_API_LVL="1.6.4"
+AMBOSO_API_LVL="1.6.5"
 at () {
     echo -n "{ call: [$(( ${#BASH_LINENO[@]} - 1 ))] "
     for ((i=${#BASH_LINENO[@]}-1;i>=0;i--)); do
@@ -79,6 +79,24 @@ function echo_amboso_version {
 }
 function echo_amboso_version_short {
   echo "$amboso_currvers"
+}
+
+function echo_timer {
+  [[ $verbose_flag -eq 0 || $quiet_flag -gt 0 ]] && return
+  st="$1"
+  msg="$2"
+  color="$3"
+  et=$(date +%s.%N)
+  runtime=$( echo "$et - $st" | bc -l )
+  display_zero=$(echo $runtime | cut -d '.' -f 1)
+  if [[ -z $display_zero ]]; then {
+    display_zero="0"
+  } else {
+    display_zero=""
+  }
+  fi
+  echo -e "\033[1;36m[TIME]\e[0m    [ \033[1;3"$color"m\"$msg\"\e[0m ] Took [ \033[1;33m$display_zero$runtime\e[0m ] seconds."
+  return
 }
 
 function check_tags {
@@ -508,6 +526,7 @@ function amboso_help {
     -q    quiet    Less output (useful but not well implemented, recommended on recursive calls)
     -s    silent    Way less output (Some output expected on stderr before the flag is applied)
     -c    control    Output dotfile \'amboso_cfg.dot\' while running.
+    -W ... START_TIME    Set start time of the program.
 
   [...]    TAG_QUERY    Ask a tag for current mode
 

--- a/amboso_fn.sh
+++ b/amboso_fn.sh
@@ -82,7 +82,10 @@ function echo_amboso_version_short {
 }
 
 function echo_timer {
-  [[ $verbose_flag -eq 0 || $quiet_flag -gt 0 ]] && return
+  if [[ $show_time_flag -eq 0 ]] ; then {
+    [[ $verbose_flag -eq 0 || $quiet_flag -gt 0 ]] && return
+  }
+  fi
   st="$1"
   msg="$2"
   color="$3"
@@ -526,6 +529,8 @@ function amboso_help {
     -q    quiet    Less output (useful but not well implemented, recommended on recursive calls)
     -s    silent    Way less output (Some output expected on stderr before the flag is applied)
     -c    control    Output dotfile \'amboso_cfg.dot\' while running.
+    -w    watch    Always display timers regardless of verbosity.
+    -X    experimental    Ignore the result of git_mode_check, which would stop git mode runs early when git status is not clean.
     -W ... START_TIME    Set start time of the program.
 
   [...]    TAG_QUERY    Ask a tag for current mode
@@ -535,7 +540,7 @@ function amboso_help {
 }
 
 function usage {
-  echo -e "Usage:  $(basename $prog_name) [(-D|-K|-M|-S|-E|-G) ...ARGS] [-TBtg] [-bripd] [-hHvVlLqc] [TAG_QUERY]\n"
+  echo -e "Usage:  $(basename $prog_name) [(-D|-K|-M|-S|-E|-G|-W) ...ARGS] [-TBtg] [-bripd] [-hHvVlLqcwX] [TAG_QUERY]\n"
   echo -e "    Query for a build version\n"
   #echo_supported_tags "$milestones_dir"
   #echo ""

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -21,3 +21,4 @@ kazoj# tests folder name
 1.6.2# -G to gen C header, check remote tags
 1.6.3# Better -G gen
 1.6.4# Gen C header for missing git tags drops errors
+1.6.5# Add global start time

--- a/bin/v1.6.5/.gitignore
+++ b/bin/v1.6.5/.gitignore
@@ -1,0 +1,3 @@
+#amboso compliant version folder, will ignore everything inside BUT the gitignore, to keep the clean dir
+*
+!.gitignore

--- a/kazoj/bone/good_vers
+++ b/kazoj/bone/good_vers
@@ -1,2 +1,2 @@
 #!/bin/bash
-"./amboso" -D "./bin" -q 1.0.0
+"./amboso" -D "./bin" -qX 1.0.0

--- a/kazoj/kulpo/bad_vers
+++ b/kazoj/kulpo/bad_vers
@@ -1,2 +1,2 @@
 #!/bin/bash
-"./amboso" -D "./bin" -q 69
+"./amboso" -D "./bin" -qX 69


### PR DESCRIPTION
- Adds `echo_timer()` to display runtimes.
- Adds `-W` to force pass start time to a call.
- Adds `-w` to force time output on a call.
- Adds `-X` to ignore `git_mode_check` result and continue execution instead of quitting early, as default.