### PR TITLE
fix: 1.9.2 missing flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export SHELL=/bin/bash
 
-VERSION="1.9.1"
-ANVIL_C_HEADER_VERSION="1.9.1"
+VERSION="1.9.2"
+ANVIL_C_HEADER_VERSION="1.9.2"
 
 ECHO_VERSION="./amboso"
 RUN_VERSION := $(shell $(ECHO_VERSION) -qv)

--- a/amboso
+++ b/amboso
@@ -29,11 +29,12 @@ kernel_release="$(uname -r)"
 kernel_version="$(uname -v)"
 machine_name="$(uname -m)"
 os_name="$(uname -o)"
-amboso_currvers="1.9.1"
-expected_AMBOSO_API_LVL="1.9.1"
-amboso_testflag_version="1.9.1"
+amboso_currvers="1.9.2"
+expected_AMBOSO_API_LVL="1.9.2"
+amboso_testflag_version="1.9.2"
 verbose_flag=0
 tell_uname_flag=0
+quiet_flag=0
 #Function to try sourcing amboso_fn.sh
 source_amboso_api() {
   if [ "$(basename "$(pwd)")" = "amboso" ] ; then {

--- a/amboso_fn.sh
+++ b/amboso_fn.sh
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-AMBOSO_API_LVL="1.9.1"
+AMBOSO_API_LVL="1.9.2"
 at () {
     printf "{ call: [$(( ${#BASH_LINENO[@]} - 1 ))] "
     for ((i=${#BASH_LINENO[@]}-1;i>=0;i--)); do

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -42,3 +42,4 @@ errortests-dir = kulpo
 1.7.4# Add print_amboso_stego_scopes()
 1.9.0# Thin amboso
 1.9.1# Add amboso init quick command
+1.9.2# Fix missing quiet_flag

--- a/bin/v1.9.2/.gitignore
+++ b/bin/v1.9.2/.gitignore
@@ -1,0 +1,3 @@
+#amboso compliant version folder, will ignore everything inside BUT the gitignore, to keep the clean dir
+*
+!.gitignore

--- a/kazoj/bone/try_amboso_sourcing
+++ b/kazoj/bone/try_amboso_sourcing
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-expected_AMBOSO_API_LVL="1.9.1"
+expected_AMBOSO_API_LVL="1.9.2"
 
 verbose_flag=1
 tell_uname_flag=0
+quiet_flag=0
 #Function to try sourcing amboso_fn.sh
 source_amboso_api() {
   if [ "$(basename "$(pwd)")" = "amboso" ] ; then {

--- a/kazoj/bone/try_amboso_sourcing.stderr
+++ b/kazoj/bone/try_amboso_sourcing.stderr
@@ -1,1 +1,1 @@
-^[[0;32m[PREP]   Running with "$AMBOSO_API_LVL" [ ^[[1;35m1.9.1^[[0;32m ]; min is { ^[[1;36m1.9.1^[[0;32m }.^[[0m$
+^[[0;32m[PREP]   Running with "$AMBOSO_API_LVL" [ ^[[1;35m1.9.2^[[0;32m ]; min is { ^[[1;36m1.9.2^[[0;32m }.^[[0m$


### PR DESCRIPTION
- Fix checking for `quiet_flag` without declaring it