### PR TITLE
feat: 1.9.3 refuse dashes in stego format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export SHELL=/bin/bash
 
-VERSION="1.9.2"
-ANVIL_C_HEADER_VERSION="1.9.2"
+VERSION="1.9.3"
+ANVIL_C_HEADER_VERSION="1.9.3"
 
 ECHO_VERSION="./amboso"
 RUN_VERSION := $(shell $(ECHO_VERSION) -qv)

--- a/amboso
+++ b/amboso
@@ -29,12 +29,13 @@ kernel_release="$(uname -r)"
 kernel_version="$(uname -v)"
 machine_name="$(uname -m)"
 os_name="$(uname -o)"
-amboso_currvers="1.9.2"
-expected_AMBOSO_API_LVL="1.9.2"
-amboso_testflag_version="1.9.2"
+amboso_currvers="1.9.3"
+expected_AMBOSO_API_LVL="1.9.3"
+amboso_testflag_version="1.9.3"
 verbose_flag=0
 tell_uname_flag=0
 quiet_flag=0
+try_default=1
 #Function to try sourcing amboso_fn.sh
 source_amboso_api() {
   if [ "$(basename "$(pwd)")" = "amboso" ] ; then {
@@ -68,7 +69,6 @@ source_amboso_api() {
       [ "$source_res" -ne 0 ] && printf "\033[1;31m[PREP]    Failed loading amboso_fn.\n\n    Using file: \"%s\".\e[0m\n" "$amboso_fn_path" >&2
     } else {
       [ "$quiet_flag" -eq 0 ] && printf "\033[0;31m[WARN]    \"%s\" was not a valid file. Not in valid super-repo.\e[0m\n" "$amboso_fn_path" >&2
-      try_default=1
     }
     fi
     if [ "$try_default" -eq 1 ] && [ -f "/usr/local/bin/amboso_fn.sh" ] ; then { #We only enter here if we failed sourcing

--- a/amboso_fn.sh
+++ b/amboso_fn.sh
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-AMBOSO_API_LVL="1.9.2"
+AMBOSO_API_LVL="1.9.3"
 at () {
     printf "{ call: [$(( ${#BASH_LINENO[@]} - 1 ))] "
     for ((i=${#BASH_LINENO[@]}-1;i>=0;i--)); do
@@ -622,9 +622,9 @@ lex_stego_file() {
             next
         }
 
-        if ($0 ~ /^\s*\[[^A-Z_\[\]\\\/\$]+\]\s*$/) {
+        if ($0 ~ /^\s*\[[^-A-Z\[\]\\\/\$]+\]\s*$/) {
             # Extract and set the current scope
-            if (match($0, /^\s*\[\s*([^A-Z_\[\]]+)\s*\]\s*$/, a)) {
+            if (match($0, /^\s*\[\s*([^-A-Z\[\]]+)\s*\]\s*$/, a)) {
                 current_scope=gensub(/\s*$/, "", "g", a[1])
                 scopes[current_scope]++
             } else {

--- a/amboso_fn.sh
+++ b/amboso_fn.sh
@@ -210,7 +210,7 @@ function amboso_init_proj {
     mkdir -p "$target_dir"/tests/ok
     mkdir -p "$target_dir"/tests/errors
 
-    printf "[build]\nsource = main.c\nbin = hello_world\nmake-vers = 0.1.0\nautomake-vers = 0.1.0\ntests = tests\n[tests]\ntests-dir = ok\nerrortests-dir = errors\n[versions]\n0.1.0#\n" > "$target_dir"/bin/stego.lock
+    printf "[build]\nsource = main.c\nbin = hello_world\nmakevers = 0.1.0\nautomakevers = 0.1.0\ntests = tests\n[tests]\ntestsdir = ok\nerrortestsdir = errors\n[versions]\n0.1.0#\n" > "$target_dir"/bin/stego.lock
 
     printf "#include <stdio.h>\nint main(void) {\nprintf(\"Hello, World!\");\nreturn 0;\n}\n" > "$target_dir"/src/main.c
 
@@ -631,7 +631,7 @@ lex_stego_file() {
                 print "\033[1;31m[LINT]\033[0m    Invalid header:    \033[1;31m" $0 "\033[0m" > "/dev/stderr"
                 error_flag=1
             }
-        } else if ($0 ~ /^[^A-Z=\[\]_\$\\\/{}]+ *= *[^A-Z=\[\]\${}]+$/) {
+        } else if ($0 ~ /^[^-A-Z=\[\]_\$\\\/{}]+ *= *[^A-Z=\[\]\${}]+$/) {
             # Check if the line is a valid variable assignment
 
             split($0, parts, "=")
@@ -685,7 +685,7 @@ lex_stego_file() {
                     scopes[current_scope]++
                 }
             }
-        } else if ($0 ~ /^[^A-Z_\[\]\$\\\/{}]+ *= *{[^}A-Z\\\$#\]\[]+ *}$/) {
+        } else if ($0 ~ /^[^-A-Z_\[\]\$\\\/{}]+ *= *{[^}A-Z\\\$#\]\[]+ *}$/) {
             # Check if line has a curly bracket rightval
             # Extract variable
             variable = gensub(/^ *"?([^{="]+)"? *=.*$/, "\\1", "g", $0)
@@ -833,9 +833,9 @@ print_amboso_stego_scopes() {
         printf "ANVIL_SOURCE: {$value}\n"
       } elif [[ $variable = "build_bin" ]]; then {
         printf "ANVIL_BIN: {$value}\n"
-      } elif [[ $variable = "build_make-vers" ]]; then {
+      } elif [[ $variable = "build_makevers" ]]; then {
         printf "ANVIL_MAKE_VERS: {$value}\n"
-      } elif [[ $variable = "build_automake-vers" ]]; then {
+      } elif [[ $variable = "build_automakevers" ]]; then {
         printf "ANVIL_AUTOMAKE_VERS: {$value}\n"
       } elif [[ $variable = "build_tests" ]]; then {
         printf "ANVIL_TESTDIR: {$value}\n"
@@ -851,9 +851,9 @@ print_amboso_stego_scopes() {
         fi
     } elif [[ $scope = "tests" ]] ; then {
         test_dir="$value"
-        if [[ $variable = "tests_tests-dir" ]] ; then {
+        if [[ $variable = "tests_testsdir" ]] ; then {
           printf "ANVIL_BONE_DIR: {$test_dir}\n"
-        } elif [[ $variable = "tests_errortests-dir" ]] ; then {
+        } elif [[ $variable = "tests_errortestsdir" ]] ; then {
           printf "ANVIL_KULPO_DIR: {$test_dir}\n"
         }
         fi
@@ -904,12 +904,12 @@ set_amboso_stego_info() {
         [[ $verbose -gt 0 ]] && printf "exec_entrypoint: {$value} <- {$exec_entrypoint}\n\n"
         exec_entrypoint="$value"
         sources_info[1]="$exec_entrypoint"
-      } elif [[ $variable = "build_make-vers" ]]; then {
+      } elif [[ $variable = "build_makevers" ]]; then {
         [[ $verbose -gt 0 ]] && printf "ANVIL_MAKE_VERS: {$value}\n"
         [[ $verbose -gt 0 ]] && printf "makefile_version: {$value} <- {$makefile_version}\n\n"
         makefile_version="$value"
         sources_info[2]="$makefile_version"
-      } elif [[ $variable = "build_automake-vers" ]]; then {
+      } elif [[ $variable = "build_automakevers" ]]; then {
         [[ $verbose -gt 0 ]] && printf "ANVIL_AUTOMAKE_VERS: {$value}\n"
         [[ $verbose -gt 0 ]] && printf "use_automake_version: {$value} <- {$use_automake_version}\n\n"
         [[ $verbose -gt 0 ]] && printf "use_autoconf_version: {$value} <- {$use_autoconf_version}\n\n"
@@ -943,11 +943,11 @@ set_amboso_stego_info() {
         fi
     } elif [[ $scope = "tests" ]] ; then {
         read_dir="$value"
-        if [[ $variable = "tests_tests-dir" ]] ; then {
+        if [[ $variable = "tests_testsdir" ]] ; then {
           [[ $verbose -gt 0 ]] && printf "ANVIL_BONE_DIR: {$read_dir}\n"
           tests_info[0]="$read_dir"
           cases_dir="${tests_info[0]}"
-        } elif [[ $variable = "tests_errortests-dir" ]] ; then {
+        } elif [[ $variable = "tests_errortestsdir" ]] ; then {
           [[ $verbose -gt 0 ]] && printf "ANVIL_KULPO_DIR: {$read_dir}\n"
           tests_info[1]="$read_dir"
           errors_dir="${tests_info[1]}"

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -43,3 +43,4 @@ errortests-dir = kulpo
 1.9.0# Thin amboso
 1.9.1# Add amboso init quick command
 1.9.2# Fix missing quiet_flag
+1.9.3# Refuse dashes in stego file

--- a/bin/stego.lock
+++ b/bin/stego.lock
@@ -2,14 +2,14 @@
 
 source = hello_world.c
 bin = hello_world
-make-vers = 0.3.0
-automake-vers = 2.0.0
+makevers = 0.3.0
+automakevers = 2.0.0
 tests = kazoj
 
 [ tests ]
 
-tests-dir = bone
-errortests-dir = kulpo
+testsdir = bone
+errortestsdir = kulpo
 
 [ versions ]
 

--- a/bin/v1.9.3/.gitignore
+++ b/bin/v1.9.3/.gitignore
@@ -1,0 +1,3 @@
+#amboso compliant version folder, will ignore everything inside BUT the gitignore, to keep the clean dir
+*
+!.gitignore

--- a/kazoj/bone/anvil_stego.stdout
+++ b/kazoj/bone/anvil_stego.stdout
@@ -1,10 +1,10 @@
 ANVIL_AUTOMAKE_VERS: {2.0.0}$
-ANVIL_BIN: {hello_world}$
 ANVIL_MAKE_VERS: {0.3.0}$
+ANVIL_BIN: {hello_world}$
 ANVIL_SOURCE: {hello_world.c}$
 ANVIL_TESTDIR: {kazoj}$
-ANVIL_KULPO_DIR: {kulpo}$
 ANVIL_BONE_DIR: {bone}$
+ANVIL_KULPO_DIR: {kulpo}$
 ANVIL_GIT_VERSION: {1.0.0}$
 ANVIL_GIT_VERSION: {1.1.0}$
 ANVIL_BASE_VERSION: {?0.1.0}$

--- a/kazoj/bone/try_amboso_sourcing
+++ b/kazoj/bone/try_amboso_sourcing
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-expected_AMBOSO_API_LVL="1.9.2"
+expected_AMBOSO_API_LVL="1.9.3"
 
 verbose_flag=1
 tell_uname_flag=0

--- a/kazoj/bone/try_amboso_sourcing.stderr
+++ b/kazoj/bone/try_amboso_sourcing.stderr
@@ -1,1 +1,1 @@
-^[[0;32m[PREP]   Running with "$AMBOSO_API_LVL" [ ^[[1;35m1.9.2^[[0;32m ]; min is { ^[[1;36m1.9.2^[[0;32m }.^[[0m$
+^[[0;32m[PREP]   Running with "$AMBOSO_API_LVL" [ ^[[1;35m1.9.3^[[0;32m ]; min is { ^[[1;36m1.9.3^[[0;32m }.^[[0m$

--- a/kazoj/kulpo/bad_stego.stderr
+++ b/kazoj/kulpo/bad_stego.stderr
@@ -10,8 +10,8 @@
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31munclosed-curly = {"this" ^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31myoink {$} ^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[ NO SPACES_ALLOWED ]^[[0m$
-^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[ no-missing-square-bracked^[[0m$
-^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[_NO_UNDERSCORES]^[[0m$
+^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[ no_missing_square_bracket^[[0m$
+^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[-NO-DASHES]^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[-NOCAPS]^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31mno[way]man^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31mno  =  "[way] man"^[[0m$

--- a/kazoj/kulpo/bad_stego.stderr
+++ b/kazoj/kulpo/bad_stego.stderr
@@ -9,6 +9,7 @@
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m{} ^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31munclosed-curly = {"this" ^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31myoink {$} ^[[0m$
+^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m-               =              farvalue ^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[ NO SPACES_ALLOWED ]^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[ no_missing_square_bracket^[[0m$
 ^[[1;31m[LINT]^[[0m    Invalid line:    ^[[1;31m[-NO-DASHES]^[[0m$

--- a/stego-examples/bad.stego
+++ b/stego-examples/bad.stego
@@ -19,8 +19,8 @@ yoink {$} #error11
 
   # These are header errors
 [ NO SPACES_ALLOWED ]
-[ no-missing-square-bracked
-[_NO_UNDERSCORES]
+[ no_missing_square_bracket
+[-NO-DASHES]
 [-NOCAPS]
 no[way]man
 no  =  "[way] man"

--- a/stego-examples/bad.stego
+++ b/stego-examples/bad.stego
@@ -15,6 +15,7 @@ under_score = 1 # error7
 {} # error9
 unclosed-curly = {"this" #error10
 yoink {$} #error11
+             -               =              farvalue #error12
 
 
   # These are header errors

--- a/stego-examples/good.stego
+++ b/stego-examples/good.stego
@@ -10,7 +10,7 @@ pi = 3.14
 
   # These are ok
 val = "myval"
-[ yes-dashes ]
+[ no_dashes ]
     [    myscope   ]
 [tight]
 foo = "bar"
@@ -18,7 +18,7 @@ pi = 3.14
 100 =     str
         100= "int"
 
-[ yes-dashes ]
+[ yes_underscores ]
              -               =              farvalue
 [    spacing  ]
 foo = b     ar
@@ -33,7 +33,7 @@ foo = "bar"
 test
 1203m12ok
 
-[yes-dashes]
+[still_no_dashes]
 val = "myval#" #comment
 "val" = "myval#" #comment
 foo = "bar"
@@ -49,7 +49,7 @@ foo = "bar"
 [oh=man]
 100 =     str
 
-[ yes-dashes ]
+[ definitely_no_dashes ]
              -               =               val
 [    white ]
 [might]

--- a/stego-examples/good.stego
+++ b/stego-examples/good.stego
@@ -19,7 +19,6 @@ pi = 3.14
         100= "int"
 
 [ yes_underscores ]
-             -               =              farvalue
 [    spacing  ]
 foo = b     ar
 [tight]
@@ -50,7 +49,6 @@ foo = "bar"
 100 =     str
 
 [ definitely_no_dashes ]
-             -               =               val
 [    white ]
 [might]
 foo = b     ar

--- a/stego-examples/lock.stego
+++ b/stego-examples/lock.stego
@@ -2,14 +2,14 @@
 
 source = hello_world.c
 bin = hello_world
-make-vers = 0.3.0
-automake-vers = 2.0.0
+makevers = 0.3.0
+automakevers = 2.0.0
 tests = kazoj
 
 [ tests ]
 
-tests-dir = bone
-errortests-dir = kulpo
+testsdir = bone
+errortestsdir = kulpo
 
 [ versions ]
 


### PR DESCRIPTION
- fix: init try_default in amboso

- feat: refuse dashes in headers and left values for stego format

- feat: update env value names to `makevers`, `automakevers`, `testsdir`, `errortestsdir`, dropping the `-`

- chore: update bad_stego test

- chore: update anvil_stego test

- chore: update stego-examples